### PR TITLE
Osst 923 - Bring code in from gitlab

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,7 +97,7 @@
         ],
         "brace-style": ["error", "1tbs"],
         "block-spacing": "error",
-        "camelcase": "error",
+        "camelcase": "off",
         "dot-location": ["error", "property"],
         "eol-last": ["error", "always"],
         "indent": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,7 +97,7 @@
         ],
         "brace-style": ["error", "1tbs"],
         "block-spacing": "error",
-        "camelcase": "off",
+        "camelcase": "off",   // Needs to be disabled for @typescript-eslint/camelcase to work
         "dot-location": ["error", "property"],
         "eol-last": ["error", "always"],
         "indent": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,7 +81,7 @@
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unused-expressions": "error",
-        "no-unused-vars": "error",
+        "no-unused-vars": "warn",   // Should be error
         "no-use-before-define": "error",
         "no-useless-call": "error",
         "no-useless-concat": "error",
@@ -117,7 +117,7 @@
         "keyword-spacing": "error",
         "new-parens": "error",
         "newline-before-return": "error",
-        "newline-per-chained-call": "error",
+        //"newline-per-chained-call": "error",  // this is also set in the typescript override
         "no-implicit-coercion": [
             "error",
             {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,7 +81,7 @@
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unused-expressions": "error",
-        "no-unused-vars": "warn",   // Should be error
+        "no-unused-vars": "off",   // Needs to be disabled for @typescript/no-unused-vars to work
         "no-use-before-define": "error",
         "no-useless-call": "error",
         "no-useless-concat": "error",

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Thumbs.db
 
 # Local History for Visual Studio Code
 .history/
+.vscode/tasks.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,11 +48,27 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/moment": {
+      "version": "2.13.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/@types/moment/-/moment-2.13.0.tgz",
+      "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
+      "requires": {
+        "moment": "*"
+      }
+    },
     "@types/node": {
       "version": "13.11.1",
       "resolved": "https://nexus.corp.indeed.com/repository/npm/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
-      "dev": true
+      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.6",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/@types/node-fetch/-/node-fetch-2.5.6.tgz",
+      "integrity": "sha512-2w0NTwMWF1d3NJMK0Uiq2UNN8htVCyOWOD0jIPjPgC5Ph/YP4dVhs9YxxcMcuLuwAslz0dVEcZQUaqkLs3IzOQ==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.28.0",
@@ -176,6 +192,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://nexus.corp.indeed.com/repository/npm/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -245,6 +266,14 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://nexus.corp.indeed.com/repository/npm/concat-map/-/concat-map-0.0.1.tgz",
@@ -286,6 +315,11 @@
       "resolved": "https://nexus.corp.indeed.com/repository/npm/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -537,6 +571,16 @@
       "resolved": "https://nexus.corp.indeed.com/repository/npm/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -800,6 +844,19 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "requires": {
+        "mime-db": "1.43.0"
+      }
+    },
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://nexus.corp.indeed.com/repository/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -830,6 +887,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://nexus.corp.indeed.com/repository/npm/ms/-/ms-2.1.2.tgz",
@@ -853,6 +915,11 @@
       "resolved": "https://nexus.corp.indeed.com/repository/npm/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://nexus.corp.indeed.com/repository/npm/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "typescript": "^3.8.3"
+        "typescript": "^3.8.3",
+        "@types/moment": "^2.13.0",
+        "@types/node-fetch": "^2.5.5",
+        "moment": "^2.24.0",
+        "node-fetch": "^2.6.0"
     },
     "devDependencies": {
         "@types/node": "^13.11.1",

--- a/src/data-fetcher.ts
+++ b/src/data-fetcher.ts
@@ -1,0 +1,35 @@
+import { OwnerDataCollection } from './owner-data-collection';
+import { RequestQueue } from './request-queue';
+
+export type RequestParams = {
+    owner: string;
+    repo?: string;
+    type: string;
+    label?: string;
+};
+
+export abstract class DataFetcher<ResultType> {
+    public process(
+        requestParams: RequestParams,
+        ownerDataCollection: OwnerDataCollection,
+        requestQueue: RequestQueue
+    ): Promise<void> {
+        return this.executeRequest(requestParams).then((result) => {
+            this.updateOwnerDataCollection(requestParams, result, ownerDataCollection);
+            this.updateRequestQueue(requestParams, result, requestQueue);
+            ownerDataCollection.save();
+        });
+    }
+
+    protected abstract executeRequest(params: RequestParams): Promise<ResultType>;
+    protected abstract updateOwnerDataCollection(
+        params: RequestParams,
+        result: ResultType,
+        ownerDataCollection: OwnerDataCollection
+    ): void;
+    protected updateRequestQueue(
+        params: RequestParams,
+        result: ResultType,
+        requestQueue: RequestQueue
+    ): void {}
+}

--- a/src/data-fetcher.ts
+++ b/src/data-fetcher.ts
@@ -31,5 +31,7 @@ export abstract class DataFetcher<ResultType> {
         params: RequestParams,
         result: ResultType,
         requestQueue: RequestQueue
-    ): void {}
+    ): void {
+        // Implemented by subclasses
+    }
 }

--- a/src/data-fetcher.ts
+++ b/src/data-fetcher.ts
@@ -28,8 +28,11 @@ export abstract class DataFetcher<ResultType> {
         ownerDataCollection: OwnerDataCollection
     ): void;
     protected updateRequestQueue(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         params: RequestParams,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         result: ResultType,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         requestQueue: RequestQueue
     ): void {
         // Implemented by subclasses

--- a/src/dependency-details-retreiver.ts
+++ b/src/dependency-details-retreiver.ts
@@ -70,7 +70,8 @@ class RestfulOwnersDataFetcher extends BaseRestfulGithubDataFetcher<string> {
         ownerDataCollection: OwnerDataCollection
     ): void {
         ownerDataCollection.updateOwnerData(params.owner, (ownerData) => {
-            ownerData.fundingUrl = fundingUrl;
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            ownerData.funding_url = fundingUrl;
 
             return ownerData;
         });
@@ -96,7 +97,8 @@ class RestfulDependenciesDataFetcher extends BaseRestfulGithubDataFetcher<undefi
             const libraryUrl = this.getURL(params);
 
             return {
-                htmlUrl: this.getURL(params, undefined),
+                // eslint-disable-next-line @typescript-eslint/camelcase
+                html_url: this.getURL(params, undefined),
                 count: ownerDataCollection.getDependentCountForLibrary(libraryUrl),
                 issues: {},
             };
@@ -137,7 +139,8 @@ class RestfulLanguageAndIssuesDataFetcher extends BaseRestfulGithubDataFetcher<
     ): void {
         ownerDataCollection.updateRepoData(params.owner, params.repo as string, (repoData) => {
             repoData.language = languageAndOpenIssuesCount.language;
-            repoData.openIssuesCount = languageAndOpenIssuesCount.openIssuesCount;
+            // eslint-disable-next-line @typescript-eslint/camelcase
+            repoData.open_issues_count = languageAndOpenIssuesCount.openIssuesCount;
 
             return repoData;
         });
@@ -210,7 +213,8 @@ class RestfulLabelDataFetcher extends BaseRestfulGithubDataFetcher<object[]> {
                             return {
                                 title: issue.title,
                                 url: issue.html_url,
-                                createdAt: issue.created_at,
+                                // eslint-disable-next-line @typescript-eslint/camelcase
+                                created_at: issue.created_at,
                                 tagged: [(params.label as string).replace(/\+/g, ' ')],
                             };
                         } else {

--- a/src/dependency-details-retreiver.ts
+++ b/src/dependency-details-retreiver.ts
@@ -82,6 +82,7 @@ class RestfulDependenciesDataFetcher extends BaseRestfulGithubDataFetcher<undefi
         const requestUrl = this.getURL(params) + '/contents/.github/';
 
         // TODO: find out why we do nothing with the result here.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         return this.httpClient.get(requestUrl).then((_) => undefined);
     }
 
@@ -90,6 +91,7 @@ class RestfulDependenciesDataFetcher extends BaseRestfulGithubDataFetcher<undefi
         _: undefined,
         ownerDataCollection: OwnerDataCollection
     ): void {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ownerDataCollection.updateRepoData(params.owner, params.repo as string, (__) => {
             const libraryUrl = this.getURL(params);
 

--- a/src/dependency-details-retreiver.ts
+++ b/src/dependency-details-retreiver.ts
@@ -1,0 +1,296 @@
+import moment from 'moment';
+import { RequestQueue, RequesteQueueEntry } from './request-queue';
+import { OwnerDataCollection } from './owner-data-collection';
+import { sleep } from './utils';
+import { DataFetcher, RequestParams } from './data-fetcher';
+import { TabDepthLogger } from './tab-level-logger';
+import { FetchHttpClient, IHttpClient } from './http';
+
+const REQUEST_DELAY_MS = 1400;
+const RELEVANT_LABELS = ['good+first+issue', 'help+wanted', 'documentation'];
+const MIN_ISSUE_DATE = moment()
+    .subtract(365, 'days')
+    .format('YYYY-MM-DD');
+
+export class DependencyDetailsRetriever {
+    public async run(abbreviated: boolean, githubToken: string): Promise<number> {
+        const requestQueue = new RequestQueue();
+        const ownerDataCollection = new OwnerDataCollection(abbreviated);
+        this.populateRequestQueue(requestQueue, ownerDataCollection, githubToken);
+        let nextRequest: RequesteQueueEntry | undefined = requestQueue.popRequest();
+        while (nextRequest) {
+            await nextRequest.dataFetcher.process(
+                nextRequest.requestParams,
+                ownerDataCollection,
+                requestQueue
+            );
+            nextRequest = requestQueue.popRequest();
+            await sleep(REQUEST_DELAY_MS);
+        }
+
+        return Promise.resolve(0);
+    }
+
+    private populateRequestQueue(
+        requestQueue: RequestQueue,
+        ownerDataCollection: OwnerDataCollection,
+        githubToken: string
+    ): void {
+        const httpClient = new FetchHttpClient(githubToken);
+        const restfulOwnersDataFetcher = new RestfulOwnersDataFetcher(httpClient);
+        const restfulDependenciesDataFetcher = new RestfulDependenciesDataFetcher(httpClient);
+        const restfulLanguageAndIssuesDataFetcher = new RestfulLanguageAndIssuesDataFetcher(
+            httpClient
+        );
+        const restfulLabelDataFetcher = new RestfulLabelDataFetcher(httpClient);
+        for (const owner of ownerDataCollection.getSortedOwners()) {
+            const ownerDataRequestParams: RequestParams = {
+                owner,
+                type: 'funding'
+            };
+            requestQueue.queueRequest(ownerDataRequestParams, restfulOwnersDataFetcher);
+            // *************** */
+
+            // iterate dependencies
+            // *************** */
+            for (const dependency of ownerDataCollection.getRepos(owner)) {
+                // CREATE contents args
+                const dependenciesDataRequestParams = {
+                    owner,
+                    repo: dependency,
+                    type: 'funding'
+                };
+                // *************** */
+
+                // CONTENTS
+                requestQueue.queueRequest(
+                    dependenciesDataRequestParams,
+                    restfulDependenciesDataFetcher
+                );
+
+                // LANGUAGE AND OPEN ISSUES
+                const languageAndOpenIssuesCountRequestParams = {
+                    owner,
+                    repo: dependency,
+                    type: 'repo'
+                };
+                requestQueue.queueRequest(
+                    languageAndOpenIssuesCountRequestParams,
+                    restfulLanguageAndIssuesDataFetcher
+                );
+
+                // LABELS
+                RELEVANT_LABELS.forEach((label) => {
+                    // CREATE labels args
+                    const labelDataRequestParams = {
+                        owner,
+                        repo: dependency,
+                        type: 'issues',
+                        label
+                    };
+                    requestQueue.queueRequest(labelDataRequestParams, restfulLabelDataFetcher);
+                });
+            }
+        }
+    }
+}
+
+abstract class BaseRestfulGithubDataFetcher<T> extends DataFetcher<T> {
+    protected httpClient: IHttpClient;
+
+    constructor(httpClient: IHttpClient) {
+        super();
+        this.httpClient = httpClient;
+    }
+
+    protected handleError(err: Error): void {
+        if (err) {
+            TabDepthLogger.error(0, err);
+        }
+    }
+
+    protected getURL(params: RequestParams, type: string = 'api'): string {
+        let subdomain = '';
+        let subdirectory = '';
+        if (type === 'api') {
+            subdomain = 'api';
+            subdirectory = 'repos';
+        }
+        return `https://${subdomain}.github.com/${subdirectory}/${params.owner}/${params.repo}`;
+    }
+
+    // TODO: Factor out other commonalities between the three RESTful fetchers here.
+}
+
+class RestfulOwnersDataFetcher extends BaseRestfulGithubDataFetcher<string> {
+    public executeRequest(params: RequestParams): Promise<string> {
+        const requestUrl = 'https://api.github.com/repos/' + params.owner + '/.github/contents/';
+
+        return this.httpClient
+            .get(requestUrl)
+            .then((responseText) => {
+                const responseJson = JSON.parse(responseText);
+                if (responseJson instanceof Object) {
+                    const err = new Error(responseJson.message);
+                    this.handleError(err);
+                    return;
+                } else if (responseJson instanceof Array) {
+                    for (const file of responseJson) {
+                        if (file.name.toLowerCase() === 'funding.yml') {
+                            const fundingUrl = file.html_url;
+                            return fundingUrl;
+                        }
+                    }
+                }
+            })
+            .catch((err) => this.handleError(err));
+    }
+
+    public updateOwnerDataCollection(
+        params: RequestParams,
+        fundingUrl: string,
+        ownerDataCollection: OwnerDataCollection
+    ): void {
+        ownerDataCollection.updateOwnerData(params.owner, (ownerData) => {
+            ownerData.funding_url = fundingUrl;
+            return ownerData;
+        });
+    }
+}
+
+class RestfulDependenciesDataFetcher extends BaseRestfulGithubDataFetcher<undefined> {
+    public executeRequest(params: RequestParams): Promise<undefined> {
+        const requestUrl = this.getURL(params) + '/contents/.github/';
+        // TODO: find out why we do nothing with the result here.
+        return this.httpClient.get(requestUrl).then((_) => undefined);
+    }
+
+    public updateOwnerDataCollection(
+        params: RequestParams,
+        _: undefined,
+        ownerDataCollection: OwnerDataCollection
+    ): void {
+        ownerDataCollection.updateRepoData(params.owner, params.repo as string, (__) => {
+            const libraryUrl = this.getURL(params);
+            return {
+                html_url: this.getURL(params, undefined),
+                count: ownerDataCollection.getDependentCountForLibrary(libraryUrl),
+                issues: {}
+            };
+        });
+    }
+}
+
+type LanguageAndOpenIssuesCount = { language: string; openIssuesCount: number; archived: boolean };
+
+class RestfulLanguageAndIssuesDataFetcher extends BaseRestfulGithubDataFetcher<
+    LanguageAndOpenIssuesCount
+> {
+    public executeRequest(params: RequestParams): Promise<LanguageAndOpenIssuesCount> {
+        const requestUrl = this.getURL(params);
+        TabDepthLogger.info(2, `Querying: ${requestUrl}`);
+        return this.httpClient
+            .get(requestUrl)
+            .then((responseText) => {
+                const responseJson = JSON.parse(responseText);
+                return {
+                    language: responseJson.language as string,
+                    openIssuesCount: responseJson.open_issues_count as number,
+                    archived: responseJson.archived as boolean
+                };
+            })
+            .catch((err) => {
+                this.handleError(err);
+                throw err;
+            });
+    }
+
+    public updateOwnerDataCollection(
+        params: RequestParams,
+        languageAndOpenIssuesCount: LanguageAndOpenIssuesCount,
+        ownerDataCollection: OwnerDataCollection
+    ): void {
+        ownerDataCollection.updateRepoData(params.owner, params.repo as string, (repoData) => {
+            repoData.language = languageAndOpenIssuesCount.language;
+            repoData.open_issues_count = languageAndOpenIssuesCount.openIssuesCount;
+            return repoData;
+        });
+    }
+
+    public updateRequestQueue(
+        params: RequestParams,
+        languageAndOpenIssuesCount: LanguageAndOpenIssuesCount,
+        requestQueue: RequestQueue
+    ): void {
+        if (
+            languageAndOpenIssuesCount.openIssuesCount === 0 ||
+            languageAndOpenIssuesCount.archived === true
+        ) {
+            TabDepthLogger.info(4, 'No Open Issues or Repo Is Archived. Skipping!');
+            if (languageAndOpenIssuesCount.archived === true) {
+                TabDepthLogger.info(3, `repoIsArchived "${params.owner}/${params.repo}"`);
+            }
+            RELEVANT_LABELS.forEach((label) => {
+                const labelDataRequestParams = {
+                    owner: params.owner,
+                    repo: params.repo,
+                    type: 'issues',
+                    label
+                };
+                requestQueue.dequeueRequest(labelDataRequestParams);
+            });
+        }
+    }
+}
+
+class RestfulLabelDataFetcher extends BaseRestfulGithubDataFetcher<object[]> {
+    public executeRequest(params: RequestParams): Promise<object[]> {
+        const requestUrl = `${this.getURL(params)}/issues?since=${MIN_ISSUE_DATE}&labels=${
+            params.label
+        }`;
+        TabDepthLogger.info(2, `Querying: ${requestUrl}`);
+        return this.httpClient
+            .get(requestUrl)
+            .then((responseText) => {
+                const listOfIssues = JSON.parse(responseText);
+                return listOfIssues;
+            })
+            .catch((err) => this.handleError(err));
+    }
+
+    public updateOwnerDataCollection(
+        params: RequestParams,
+        // tslint:disable-next-line: no-any
+        listOfIssues: any[],
+        ownerDataCollection: OwnerDataCollection
+    ): void {
+        if (listOfIssues.length > 0) {
+            TabDepthLogger.info(5, 'Found Issues!');
+            listOfIssues.forEach((issue) => {
+                // If the issue is actually a pull request, skip it and move on.
+                if (issue.hasOwnProperty('pull_request') === true) {
+                    return;
+                }
+
+                ownerDataCollection.updateIssueData(
+                    params.owner,
+                    params.repo as string,
+                    issue.html_url as string,
+                    (issueData) => {
+                        if (!issueData) {
+                            return {
+                                title: issue.title,
+                                url: issue.html_url,
+                                created_at: issue.created_at,
+                                tagged: [(params.label as string).replace(/\+/g, ' ')]
+                            };
+                        } else {
+                            issueData.tagged.push((params.label as string).replace(/\+/g, ' '));
+                            return issueData;
+                        }
+                    }
+                );
+            });
+        }
+    }
+}

--- a/src/dependency-details-retreiver.ts
+++ b/src/dependency-details-retreiver.ts
@@ -194,7 +194,7 @@ class RestfulLabelDataFetcher extends BaseRestfulGithubDataFetcher<object[]> {
             TabDepthLogger.info(5, 'Found Issues!');
             listOfIssues.forEach((issue) => {
                 // If the issue is actually a pull request, skip it and move on.
-                if (issue.hasOwnProperty('pull_request') === true) {
+                if (Object.prototype.hasOwnProperty.call(issue, 'pull_request') === true) {
                     return;
                 }
 

--- a/src/dependency-details-retreiver.ts
+++ b/src/dependency-details-retreiver.ts
@@ -4,16 +4,16 @@ import { OwnerDataCollection } from './owner-data-collection';
 import { sleep } from './utils';
 import { DataFetcher, RequestParams } from './data-fetcher';
 import { TabDepthLogger } from './tab-level-logger';
-import { FetchHttpClient, IHttpClient } from './http';
+import { FetchHttpClient, HttpClient } from './http';
 
 const REQUEST_DELAY_MS = 1400;
 const RELEVANT_LABELS = ['good+first+issue', 'help+wanted', 'documentation'];
 const MIN_ISSUE_DATE = moment().subtract(365, 'days').format('YYYY-MM-DD');
 
 abstract class BaseRestfulGithubDataFetcher<T> extends DataFetcher<T> {
-    protected httpClient: IHttpClient;
+    protected httpClient: HttpClient;
 
-    constructor(httpClient: IHttpClient) {
+    constructor(httpClient: HttpClient) {
         super();
         this.httpClient = httpClient;
     }

--- a/src/dependency-details-retreiver.ts
+++ b/src/dependency-details-retreiver.ts
@@ -70,7 +70,7 @@ class RestfulOwnersDataFetcher extends BaseRestfulGithubDataFetcher<string> {
         ownerDataCollection: OwnerDataCollection
     ): void {
         ownerDataCollection.updateOwnerData(params.owner, (ownerData) => {
-            ownerData.funding_url = fundingUrl;
+            ownerData.fundingUrl = fundingUrl;
 
             return ownerData;
         });
@@ -94,7 +94,7 @@ class RestfulDependenciesDataFetcher extends BaseRestfulGithubDataFetcher<undefi
             const libraryUrl = this.getURL(params);
 
             return {
-                html_url: this.getURL(params, undefined),
+                htmlUrl: this.getURL(params, undefined),
                 count: ownerDataCollection.getDependentCountForLibrary(libraryUrl),
                 issues: {},
             };
@@ -135,7 +135,7 @@ class RestfulLanguageAndIssuesDataFetcher extends BaseRestfulGithubDataFetcher<
     ): void {
         ownerDataCollection.updateRepoData(params.owner, params.repo as string, (repoData) => {
             repoData.language = languageAndOpenIssuesCount.language;
-            repoData.open_issues_count = languageAndOpenIssuesCount.openIssuesCount;
+            repoData.openIssuesCount = languageAndOpenIssuesCount.openIssuesCount;
 
             return repoData;
         });
@@ -207,7 +207,7 @@ class RestfulLabelDataFetcher extends BaseRestfulGithubDataFetcher<object[]> {
                             return {
                                 title: issue.title,
                                 url: issue.html_url,
-                                created_at: issue.created_at,
+                                createdAt: issue.created_at,
                                 tagged: [(params.label as string).replace(/\+/g, ' ')],
                             };
                         } else {

--- a/src/dependency-details-retreiver.ts
+++ b/src/dependency-details-retreiver.ts
@@ -189,6 +189,7 @@ class RestfulLabelDataFetcher extends BaseRestfulGithubDataFetcher<object[]> {
     public updateOwnerDataCollection(
         params: RequestParams,
         // tslint:disable-next-line: no-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         listOfIssues: any[],
         ownerDataCollection: OwnerDataCollection
     ): void {

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,32 @@
+import fetch, { Response } from 'node-fetch';
+
+export interface IHttpClient {
+    get(url: string): Promise<string>;
+}
+
+type Headers = { 'User-Agent': string; Authorization: string };
+
+export class FetchHttpClient {
+    private readonly headers: Headers;
+
+    constructor(authorizationToken: string) {
+        this.headers = {
+            'User-Agent': 'request',
+            Authorization: 'token ' + authorizationToken
+        };
+    }
+
+    public get(url: string): Promise<string> {
+        return fetch(url, { headers: this.headers }).then((resp) => {
+            this.checkForRateLimiting(resp);
+            return resp.text();
+        });
+    }
+
+    private checkForRateLimiting(response: Response): void {
+        if (response.status === 403) {
+            console.error('RATE LIMITED');
+        }
+        return;
+    }
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -12,13 +12,14 @@ export class FetchHttpClient {
     constructor(authorizationToken: string) {
         this.headers = {
             'User-Agent': 'request',
-            Authorization: 'token ' + authorizationToken
+            Authorization: 'token ' + authorizationToken,
         };
     }
 
     public get(url: string): Promise<string> {
         return fetch(url, { headers: this.headers }).then((resp) => {
             this.checkForRateLimiting(resp);
+
             return resp.text();
         });
     }
@@ -27,6 +28,7 @@ export class FetchHttpClient {
         if (response.status === 403) {
             console.error('RATE LIMITED');
         }
+
         return;
     }
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,6 @@
 import fetch, { Response } from 'node-fetch';
 
-export interface IHttpClient {
+export interface HttpClient {
     get(url: string): Promise<string>;
 }
 

--- a/src/mariner.ts
+++ b/src/mariner.ts
@@ -1,1 +1,0 @@
-console.log('hello, welcome to mariner!');

--- a/src/owner-data-collection.ts
+++ b/src/owner-data-collection.ts
@@ -36,7 +36,7 @@ export class OwnerDataCollection {
     constructor(abbreviated: boolean) {
         this.abbreviated = abbreviated;
         const contents = fs.readFileSync('./CountSourceFiles/mini.json', {
-            encoding: 'utf8'
+            encoding: 'utf8',
         });
         this.libraryUrlToDependentCount = JSON.parse(contents);
         this.initialize();
@@ -88,7 +88,7 @@ export class OwnerDataCollection {
 
     public save(): void {
         fs.writeFileSync(this.OUTPUT_FILE_PATH, JSON.stringify(this.ownerDataMap), {
-            encoding: 'utf8'
+            encoding: 'utf8',
         });
     }
 
@@ -119,9 +119,9 @@ export class OwnerDataCollection {
                         repos: {
                             [repo]: {
                                 count: dependentCount,
-                                issues: {}
-                            }
-                        }
+                                issues: {},
+                            },
+                        },
                     };
                 }
                 const ownerData = this.ownerDataMap[owner];
@@ -135,6 +135,7 @@ export class OwnerDataCollection {
         this.ownersArray.sort((a, b) => {
             const bb = this.ownerDataMap[b];
             const aa = this.ownerDataMap[a];
+
             return bb.dependent_count - aa.dependent_count;
         });
     }

--- a/src/owner-data-collection.ts
+++ b/src/owner-data-collection.ts
@@ -83,7 +83,10 @@ export class OwnerDataCollection {
     }
 
     public hasIssue(owner: string, repo: string, issue: string): boolean {
-        return this.ownerDataMap[owner].repos[repo].issues.hasOwnProperty(issue);
+        return Object.prototype.hasOwnProperty.call(
+            this.ownerDataMap[owner].repos[repo].issues,
+            issue
+        );
     }
 
     public save(): void {
@@ -94,7 +97,9 @@ export class OwnerDataCollection {
 
     private initialize(): void {
         for (const libraryUrl in this.libraryUrlToDependentCount) {
-            if (!this.libraryUrlToDependentCount.hasOwnProperty(libraryUrl)) {
+            if (
+                !Object.prototype.hasOwnProperty.call(this.libraryUrlToDependentCount, libraryUrl)
+            ) {
                 continue;
             }
             // skip the library if it's number of dependents is below the abbreviationThreshold
@@ -108,7 +113,7 @@ export class OwnerDataCollection {
                     .replace('https://api.github.com/repos/', '')
                     .split('/');
                 // parse owners master counts out of dependencies list
-                if (this.ownerDataMap.hasOwnProperty(owner)) {
+                if (Object.prototype.hasOwnProperty.call(this.ownerDataMap.hasOwnProperty, owner)) {
                     this.ownerDataMap[owner].dependentCount += dependentCount;
                 } else {
                     this.ownersArray.push(owner);

--- a/src/owner-data-collection.ts
+++ b/src/owner-data-collection.ts
@@ -4,23 +4,23 @@ import { TabDepthLogger } from './tab-level-logger';
 type IssueData = {
     title: string;
     url: string;
-    created_at: string;
+    createdAt: string;
     tagged: string[];
 };
 
 type RepoData = {
-    html_url?: string;
-    open_issues_count?: number;
+    htmlUrl?: string;
+    openIssuesCount?: number;
     language?: string;
-    funding_url?: string;
+    fundingUrl?: string;
     count: number;
     issues: { [key: string]: IssueData };
 };
 type OwnerData = {
-    funding_url?: string;
-    html_url: string;
-    dependent_count: number;
-    dependency_count: number;
+    fundingUrl?: string;
+    htmlUrl: string;
+    dependentCount: number;
+    dependencyCount: number;
     repos: { [key: string]: RepoData };
 };
 
@@ -109,13 +109,13 @@ export class OwnerDataCollection {
                     .split('/');
                 // parse owners master counts out of dependencies list
                 if (this.ownerDataMap.hasOwnProperty(owner)) {
-                    this.ownerDataMap[owner].dependent_count += dependentCount;
+                    this.ownerDataMap[owner].dependentCount += dependentCount;
                 } else {
                     this.ownersArray.push(owner);
                     this.ownerDataMap[owner] = {
-                        html_url: 'https://github.com/' + owner,
-                        dependent_count: dependentCount,
-                        dependency_count: 1,
+                        htmlUrl: 'https://github.com/' + owner,
+                        dependentCount: dependentCount,
+                        dependencyCount: 1,
                         repos: {
                             [repo]: {
                                 count: dependentCount,
@@ -125,7 +125,7 @@ export class OwnerDataCollection {
                     };
                 }
                 const ownerData = this.ownerDataMap[owner];
-                ownerData.dependency_count = Object.keys(ownerData.repos).length;
+                ownerData.dependencyCount = Object.keys(ownerData.repos).length;
             } else {
                 TabDepthLogger.info(0, `Not a GitHub Library. Skipping: ${libraryUrl}`);
             }
@@ -136,7 +136,7 @@ export class OwnerDataCollection {
             const bb = this.ownerDataMap[b];
             const aa = this.ownerDataMap[a];
 
-            return bb.dependent_count - aa.dependent_count;
+            return bb.dependentCount - aa.dependentCount;
         });
     }
 }

--- a/src/owner-data-collection.ts
+++ b/src/owner-data-collection.ts
@@ -103,7 +103,7 @@ export class OwnerDataCollection {
                 continue;
             }
 
-            if (libraryUrl.match(/^https\:\/\/api.github.com\/repos\//)) {
+            if (libraryUrl.match(/^https:\/\/api.github.com\/repos\//)) {
                 const [owner, repo] = libraryUrl
                     .replace('https://api.github.com/repos/', '')
                     .split('/');

--- a/src/owner-data-collection.ts
+++ b/src/owner-data-collection.ts
@@ -1,0 +1,141 @@
+import fs from 'fs';
+import { TabDepthLogger } from './tab-level-logger';
+
+type IssueData = {
+    title: string;
+    url: string;
+    created_at: string;
+    tagged: string[];
+};
+
+type RepoData = {
+    html_url?: string;
+    open_issues_count?: number;
+    language?: string;
+    funding_url?: string;
+    count: number;
+    issues: { [key: string]: IssueData };
+};
+type OwnerData = {
+    funding_url?: string;
+    html_url: string;
+    dependent_count: number;
+    dependency_count: number;
+    repos: { [key: string]: RepoData };
+};
+
+export class OwnerDataCollection {
+    private readonly libraryUrlToDependentCount: { [key: string]: number };
+    private readonly OUTPUT_FILE_PATH = './Temp/analysisOutputRaw.json';
+    private readonly abbreviated: boolean;
+    private readonly abbreviationThreshold: number = 5;
+
+    private readonly ownersArray: string[] = [];
+    private readonly ownerDataMap: { [key: string]: OwnerData } = {};
+
+    constructor(abbreviated: boolean) {
+        this.abbreviated = abbreviated;
+        const contents = fs.readFileSync('./CountSourceFiles/mini.json', {
+            encoding: 'utf8'
+        });
+        this.libraryUrlToDependentCount = JSON.parse(contents);
+        this.initialize();
+    }
+
+    public getSortedOwners(): string[] {
+        // return a copy so that it cannot be manipulated externally.
+        return this.ownersArray.slice();
+    }
+
+    public getRepos(owner: string): string[] {
+        return Object.keys(this.ownerDataMap[owner].repos);
+    }
+
+    public updateOwnerData(
+        owner: string,
+        updateFunction: (ownerData: OwnerData) => OwnerData
+    ): void {
+        const ownerData = this.ownerDataMap[owner];
+        this.ownerDataMap[owner] = updateFunction(ownerData);
+    }
+
+    public updateRepoData(
+        owner: string,
+        repo: string,
+        updateFunction: (repoData: RepoData) => RepoData
+    ): void {
+        const repoData = this.ownerDataMap[owner].repos[repo];
+        this.ownerDataMap[owner].repos[repo] = updateFunction(repoData);
+    }
+
+    public updateIssueData(
+        owner: string,
+        repo: string,
+        issue: string,
+        updateFunction: (issueData: IssueData) => IssueData
+    ): void {
+        const issueData = this.ownerDataMap[owner].repos[repo].issues[issue];
+        this.ownerDataMap[owner].repos[repo].issues[issue] = updateFunction(issueData);
+    }
+
+    public getDependentCountForLibrary(library: string): number {
+        return this.libraryUrlToDependentCount[library];
+    }
+
+    public hasIssue(owner: string, repo: string, issue: string): boolean {
+        return this.ownerDataMap[owner].repos[repo].issues.hasOwnProperty(issue);
+    }
+
+    public save(): void {
+        fs.writeFileSync(this.OUTPUT_FILE_PATH, JSON.stringify(this.ownerDataMap), {
+            encoding: 'utf8'
+        });
+    }
+
+    private initialize(): void {
+        for (const libraryUrl in this.libraryUrlToDependentCount) {
+            if (!this.libraryUrlToDependentCount.hasOwnProperty(libraryUrl)) {
+                continue;
+            }
+            // skip the library if it's number of dependents is below the abbreviationThreshold
+            const dependentCount = this.libraryUrlToDependentCount[libraryUrl];
+            if (this.abbreviated && dependentCount < this.abbreviationThreshold) {
+                continue;
+            }
+
+            if (libraryUrl.match(/^https\:\/\/api.github.com\/repos\//)) {
+                const [owner, repo] = libraryUrl
+                    .replace('https://api.github.com/repos/', '')
+                    .split('/');
+                // parse owners master counts out of dependencies list
+                if (this.ownerDataMap.hasOwnProperty(owner)) {
+                    this.ownerDataMap[owner].dependent_count += dependentCount;
+                } else {
+                    this.ownersArray.push(owner);
+                    this.ownerDataMap[owner] = {
+                        html_url: 'https://github.com/' + owner,
+                        dependent_count: dependentCount,
+                        dependency_count: 1,
+                        repos: {
+                            [repo]: {
+                                count: dependentCount,
+                                issues: {}
+                            }
+                        }
+                    };
+                }
+                const ownerData = this.ownerDataMap[owner];
+                ownerData.dependency_count = Object.keys(ownerData.repos).length;
+            } else {
+                TabDepthLogger.info(0, `Not a GitHub Library. Skipping: ${libraryUrl}`);
+            }
+        }
+
+        // sort the owners master counts
+        this.ownersArray.sort((a, b) => {
+            const bb = this.ownerDataMap[b];
+            const aa = this.ownerDataMap[a];
+            return bb.dependent_count - aa.dependent_count;
+        });
+    }
+}

--- a/src/owner-data-collection.ts
+++ b/src/owner-data-collection.ts
@@ -4,23 +4,31 @@ import { TabDepthLogger } from './tab-level-logger';
 type IssueData = {
     title: string;
     url: string;
-    createdAt: string;
+    // eslint-disable-next-line camelcase
+    created_at: string;
     tagged: string[];
 };
 
 type RepoData = {
-    htmlUrl?: string;
-    openIssuesCount?: number;
+    // eslint-disable-next-line camelcase
+    html_url?: string;
+    // eslint-disable-next-line camelcase
+    open_issues_count?: number;
     language?: string;
-    fundingUrl?: string;
+    // eslint-disable-next-line camelcase
+    funding_url?: string;
     count: number;
     issues: { [key: string]: IssueData };
 };
 type OwnerData = {
-    fundingUrl?: string;
-    htmlUrl: string;
-    dependentCount: number;
-    dependencyCount: number;
+    // eslint-disable-next-line camelcase
+    funding_url?: string;
+    // eslint-disable-next-line camelcase
+    html_url: string;
+    // eslint-disable-next-line camelcase
+    dependent_count: number;
+    // eslint-disable-next-line camelcase
+    dependency_count: number;
     repos: { [key: string]: RepoData };
 };
 
@@ -114,13 +122,17 @@ export class OwnerDataCollection {
                     .split('/');
                 // parse owners master counts out of dependencies list
                 if (Object.prototype.hasOwnProperty.call(this.ownerDataMap.hasOwnProperty, owner)) {
-                    this.ownerDataMap[owner].dependentCount += dependentCount;
+                    // eslint-disable-next-line @typescript-eslint/camelcase
+                    this.ownerDataMap[owner].dependent_count += dependentCount;
                 } else {
                     this.ownersArray.push(owner);
                     this.ownerDataMap[owner] = {
-                        htmlUrl: 'https://github.com/' + owner,
-                        dependentCount: dependentCount,
-                        dependencyCount: 1,
+                        // eslint-disable-next-line @typescript-eslint/camelcase
+                        html_url: 'https://github.com/' + owner,
+                        // eslint-disable-next-line @typescript-eslint/camelcase
+                        dependent_count: dependentCount,
+                        // eslint-disable-next-line @typescript-eslint/camelcase
+                        dependency_count: 1,
                         repos: {
                             [repo]: {
                                 count: dependentCount,
@@ -130,7 +142,8 @@ export class OwnerDataCollection {
                     };
                 }
                 const ownerData = this.ownerDataMap[owner];
-                ownerData.dependencyCount = Object.keys(ownerData.repos).length;
+                // eslint-disable-next-line @typescript-eslint/camelcase
+                ownerData.dependency_count = Object.keys(ownerData.repos).length;
             } else {
                 TabDepthLogger.info(0, `Not a GitHub Library. Skipping: ${libraryUrl}`);
             }
@@ -141,7 +154,7 @@ export class OwnerDataCollection {
             const bb = this.ownerDataMap[b];
             const aa = this.ownerDataMap[a];
 
-            return bb.dependentCount - aa.dependentCount;
+            return bb.dependent_count - aa.dependent_count;
         });
     }
 }

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -36,11 +36,13 @@ export class RequestQueue {
             request = this.requestQueue.get(key);
             this.requestQueue.remove(key);
         }
+
         return request;
     }
 
     private createKeyFromParams(params: RequestParams): string {
         const key = `${params.owner}'-'${params.repo}'-'${params.type}'-'${params.label}`;
+
         return key;
     }
 }

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -1,0 +1,46 @@
+import { OrderedMap } from './utils';
+import { DataFetcher, RequestParams } from './data-fetcher';
+import { TabDepthLogger } from './tab-level-logger';
+
+export class RequesteQueueEntry {
+    public requestParams: RequestParams;
+    // tslint:disable-next-line: no-any
+    public dataFetcher: DataFetcher<any>;
+
+    // tslint:disable-next-line: no-any
+    constructor(requestParams: RequestParams, dataFetcher: DataFetcher<any>) {
+        this.requestParams = requestParams;
+        this.dataFetcher = dataFetcher;
+    }
+}
+
+export class RequestQueue {
+    private readonly requestQueue: OrderedMap<string, RequesteQueueEntry> = new OrderedMap();
+
+    // tslint:disable-next-line: no-any
+    public queueRequest(requestParams: RequestParams, dataFetcher: DataFetcher<any>): void {
+        const key = this.createKeyFromParams(requestParams);
+        this.requestQueue.add(key, new RequesteQueueEntry(requestParams, dataFetcher));
+    }
+
+    public dequeueRequest(requestParams: RequestParams): void {
+        const key = this.createKeyFromParams(requestParams);
+        TabDepthLogger.info(5, `Dequeuing: ${key}`);
+        this.requestQueue.remove(key);
+    }
+
+    public popRequest(): RequesteQueueEntry | undefined {
+        const key = this.requestQueue.firstKey();
+        let request;
+        if (key) {
+            request = this.requestQueue.get(key);
+            this.requestQueue.remove(key);
+        }
+        return request;
+    }
+
+    private createKeyFromParams(params: RequestParams): string {
+        const key = `${params.owner}'-'${params.repo}'-'${params.type}'-'${params.label}`;
+        return key;
+    }
+}

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -5,10 +5,10 @@ import { TabDepthLogger } from './tab-level-logger';
 export class RequesteQueueEntry {
     public requestParams: RequestParams;
     // tslint:disable-next-line: no-any
-    public dataFetcher: DataFetcher<any>;
+    public dataFetcher: DataFetcher<unknown>;
 
     // tslint:disable-next-line: no-any
-    constructor(requestParams: RequestParams, dataFetcher: DataFetcher<any>) {
+    constructor(requestParams: RequestParams, dataFetcher: DataFetcher<unknown>) {
         this.requestParams = requestParams;
         this.dataFetcher = dataFetcher;
     }
@@ -18,7 +18,7 @@ export class RequestQueue {
     private readonly requestQueue: OrderedMap<string, RequesteQueueEntry> = new OrderedMap();
 
     // tslint:disable-next-line: no-any
-    public queueRequest(requestParams: RequestParams, dataFetcher: DataFetcher<any>): void {
+    public queueRequest(requestParams: RequestParams, dataFetcher: DataFetcher<unknown>): void {
         const key = this.createKeyFromParams(requestParams);
         this.requestQueue.add(key, new RequesteQueueEntry(requestParams, dataFetcher));
     }

--- a/src/tab-level-logger.ts
+++ b/src/tab-level-logger.ts
@@ -1,14 +1,19 @@
-import Logger from '@indeed/logger';
-
-const LOGGER = new Logger();
 const TAB = '   ';
+
+function logInfo(message: string): void {
+    console.log('INFO: ' + message);
+}
+
+function logError(message: string): void {
+    console.log('ERROR: ' + message);
+}
 
 export class TabDepthLogger {
     public static info(depth: number, message: string): void {
-        LOGGER.info(TAB.repeat(depth) + message);
+        logInfo(TAB.repeat(depth) + message);
     }
 
     public static error(depth: number, error: Error): void {
-        LOGGER.error(TAB.repeat(depth) + error.message);
+        logError(TAB.repeat(depth) + error.message);
     }
 }

--- a/src/tab-level-logger.ts
+++ b/src/tab-level-logger.ts
@@ -1,0 +1,14 @@
+import Logger from '@indeed/logger';
+
+const LOGGER = new Logger();
+const TAB = '   ';
+
+export class TabDepthLogger {
+    public static info(depth: number, message: string): void {
+        LOGGER.info(TAB.repeat(depth) + message);
+    }
+
+    public static error(depth: number, error: Error): void {
+        LOGGER.error(TAB.repeat(depth) + error.message);
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,7 @@ export class OrderedMap<K, V> {
         if (this.ks.length > 0) {
             return this.ks[0];
         }
+
         return undefined;
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,32 @@
+export function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class OrderedMap<K, V> {
+    private ks: K[] = [];
+    private readonly map: Map<K, V> = new Map();
+
+    public add(k: K, v: V): void {
+        if (this.map.has(k)) {
+            this.remove(k);
+        }
+        this.ks.push(k);
+        this.map.set(k, v);
+    }
+
+    public remove(k: K): void {
+        this.ks = this.ks.filter((key) => key !== k);
+        this.map.delete(k);
+    }
+
+    public get(k: K): V | undefined {
+        return this.map.get(k);
+    }
+
+    public firstKey(): K | undefined {
+        if (this.ks.length > 0) {
+            return this.ks[0];
+        }
+        return undefined;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,57 +1,52 @@
 {
-    "compilerOptions": {
-      /* Basic Options */
-      "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-      "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-      // "lib": [],                             /* Specify library files to be included in the compilation. */
-      // "allowJs": true,                       /* Allow javascript files to be compiled. */
-      // "checkJs": true,                       /* Report errors in .js files. */
-      // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-      // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-      // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-      // "outFile": "./",                       /* Concatenate and emit output to single file. */
-      // "outDir": "./",                        /* Redirect output structure to the directory. */
-      // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-      // "removeComments": true,                /* Do not emit comments to output. */
-      // "noEmit": true,                        /* Do not emit outputs. */
-      // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-      // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-      // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-  
-      /* Strict Type-Checking Options */
-      "strict": true,                           /* Enable all strict type-checking options. */
-      // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-      // "strictNullChecks": true,              /* Enable strict null checks. */
-      // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-      // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-      // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-      // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-  
-      /* Additional Checks */
-      // "noUnusedLocals": true,                /* Report errors on unused locals. */
-      // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-      // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-      // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-  
-      /* Module Resolution Options */
-      // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-      // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-      // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-      // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-      // "typeRoots": [],                       /* List of folders to include type definitions from. */
-      // "types": [],                           /* Type declaration files to be included in compilation. */
-      // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-      "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-      // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-  
-      /* Source Map Options */
-      // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-      // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-      // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-      // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-  
-      /* Experimental Options */
-      // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-      // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    }
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    /* Strict Type-Checking Options */
+    "strict": true, /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,60 +1,59 @@
 {
-    "compilerOptions": {
-      /* Basic Options */
-      "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-      "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-      // "lib": [],                             /* Specify library files to be included in the compilation. */
-      // "allowJs": true,                       /* Allow javascript files to be compiled. */
-      // "checkJs": true,                       /* Report errors in .js files. */
-      // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-      "declaration": true,                      /* Generates corresponding '.d.ts' file. */
-      // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-      // "outFile": "./",                       /* Concatenate and emit output to single file. */
-      "outDir": "./dist",                        /* Redirect output structure to the directory. */
-      // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-      // "removeComments": true,                /* Do not emit comments to output. */
-      // "noEmit": true,                        /* Do not emit outputs. */
-      // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-      // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-      // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-  
-      /* Strict Type-Checking Options */
-      "strict": true,                           /* Enable all strict type-checking options. */
-      // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-      // "strictNullChecks": true,              /* Enable strict null checks. */
-      // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-      // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-      // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-      // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-  
-      /* Additional Checks */
-      // "noUnusedLocals": true,                /* Report errors on unused locals. */
-      // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-      // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-      // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-  
-      /* Module Resolution Options */
-      // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-      // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-      // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-      // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-      // "typeRoots": [],                       /* List of folders to include type definitions from. */
-      // "types": [],                           /* Type declaration files to be included in compilation. */
-      // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-      "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-      // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-  
-      /* Source Map Options */
-      // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-      // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-      // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-      // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-  
-      /* Experimental Options */
-      // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-      // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-    },
-    "include": ["src"],
-    "exclude": ["node_modules", "**/__tests__/*"]
-  }
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "**/__tests__/*"]
 }


### PR DESCRIPTION
This brings in most of the Mariner "Analyze Dependencies" code from our internal repo. I fixed and disabled a bunch of lint errors. There is a pretty reasonable chance this broke the code, but we have no automated tests. It will be easier to test it after we remove the hard-coded input and output file paths, so once that work is in, we can test and debug the rest of the code. 
