### PR TITLE
V0.1.1 package.lock fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Run ```node dist/indexExample.js``` to run the example program. It requires inte
 since it calls the GitHub API. It will take a couple minutes to complete. 
 Some of the output includes the word "ERROR", so don't panic. 
 
+## Local testing of the npm packaging
+
+You should have local copies of both the oss-mariner project and the project that will include it. 
+In the oss-mariner project, run ```npm link```. This will "publish" oss-mariner locally on your 
+computer. Then in the other project, run ```npm link oss-mariner```. 
+This will replace the public npm version of oss-mariner with your local copy. 
+
 ## Project Maintainers
 
 The [Open Source team at Indeed](https://opensource.indeedeng.io/), who can be reached at opensource@indeed.com.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ The [Open Source team at Indeed](https://opensource.indeedeng.io/), who can be r
 
 ## How to Publish
 
-1. If you are a maintainer, you can follow these steps to publish a new version of the package:
+If you are a maintainer, you can follow these steps to publish a new version of the package:
 1. Be sure the version number in package.json is correct
+1. Run ```npm install``` to update package-lock.json
+1. Run ```npm run build``` and ```npm run lint``` to make sure there are no errors
 1. Login to npm if you haven’t already: npm login
 1. Do a dry run to make sure the package looks good: npm publish --dry-run
 1. Publish: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-mariner",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "oss-mariner",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "A node.js library for analyzing open source library dependencies",
-    "main": "dist/mariner.js",
-    "types": "dist/mariner.d.ts",
+    "main": "dist/dependency-details-retriever.js",
+    "types": "dist/dependency-details-retriever.d.ts",
     "author": "",
     "license": "Apache-2.0",
     "scripts": {

--- a/src/mariner.ts
+++ b/src/mariner.ts
@@ -1,1 +1,0 @@
-export { DependencyDetailsRetriever } from './dependency-details-retriever';

--- a/src/mariner.ts
+++ b/src/mariner.ts
@@ -1,0 +1,1 @@
+export { DependencyDetailsRetriever } from './dependency-details-retriever';


### PR DESCRIPTION
This included Carlos's addition of an export at the top of the main class file. It also adds the main class file to package.json, and updates the README to mention running npm install before publishing. Finally, it bumps the version to 0.1.1 so we can publish this. 