### PR TITLE
Progress tracking OSST-943

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"Error: no test specified\" && exit 1",
         "check": "npx eslint --print-config src/* | npx eslint-config-prettier-check",
         "lint": "npx eslint src/ --ext .js,.ts && echo 'Lint complete'",
-        "lint:fix": "npx eslint src/ --fix . --ext .js,.ts && echo 'Fixed errors'",
+        "lint:fix": "npx eslint src/ --fix --ext .js,.ts && echo 'Fixed errors'",
         "build": "tsc",
         "prepublish": "tsc",
         "NOTYET-prepublishOnly": "npm test && npm run lint",

--- a/src/data-fetcher.ts
+++ b/src/data-fetcher.ts
@@ -17,7 +17,6 @@ export abstract class DataFetcher<ResultType> {
         return this.executeRequest(requestParams).then((result) => {
             this.updateOwnerDataCollection(requestParams, result, ownerDataCollection);
             this.updateRequestQueue(requestParams, result, requestQueue);
-            ownerDataCollection.save();
         });
     }
     protected abstract executeRequest(params: RequestParams): Promise<ResultType>;

--- a/src/dependency-details-retriever.ts
+++ b/src/dependency-details-retriever.ts
@@ -127,7 +127,7 @@ type LanguageAndOpenIssuesCount = { language: string; openIssuesCount: number; a
 
 class RestfulLanguageAndIssuesDataFetcher extends BaseRestfulGithubDataFetcher<
     LanguageAndOpenIssuesCount
-> {
+    > {
     public executeRequest(params: RequestParams): Promise<LanguageAndOpenIssuesCount> {
         const requestUrl = this.getURL(params);
         TabDepthLogger.info(2, `Querying: ${requestUrl}`);
@@ -193,7 +193,7 @@ class RestfulLabelDataFetcher extends BaseRestfulGithubDataFetcher<object[]> {
     public executeRequest(params: RequestParams): Promise<object[]> {
         const requestUrl = `${this.getURL(params)}/issues?since=${MIN_ISSUE_DATE}&labels=${
             params.label
-        }`;
+            }`;
         TabDepthLogger.info(2, `Querying: ${requestUrl}`);
 
         return this.httpClient
@@ -260,16 +260,23 @@ export class DependencyDetailsRetriever {
             abbreviated
         );
         this.populateRequestQueue(requestQueue, ownerDataCollection, githubToken);
-        const totalNumberOfRequests = requestQueue.getNumberOfRequests(); 
+        const totalNumberOfRequests = requestQueue.getNumberOfRequests();
         let nextRequest: RequesteQueueEntry | undefined = requestQueue.popRequest();
+        TabDepthLogger.info(0, `Processing ${totalNumberOfRequests} requests`);
         while (nextRequest) {
             await nextRequest.dataFetcher.process(
                 nextRequest.requestParams,
                 ownerDataCollection,
                 requestQueue
             );
-            const numberCompleted = totalNumberOfRequests - requestQueue.getNumberOfRequests();
-            TabDepthLogger.info(0, `Completed: ${numberCompleted} of ${totalNumberOfRequests}`);
+            const completedNumberOfRequests =
+                totalNumberOfRequests - requestQueue.getNumberOfRequests();
+            if (completedNumberOfRequests % 10 === 0) {
+                TabDepthLogger.info(
+                    0,
+                    `Completed: ${completedNumberOfRequests} of ${totalNumberOfRequests}`
+                );
+            }
             nextRequest = requestQueue.popRequest();
             await sleep(REQUEST_DELAY_MS);
         }

--- a/src/dependency-details-retriever.ts
+++ b/src/dependency-details-retriever.ts
@@ -260,6 +260,7 @@ export class DependencyDetailsRetriever {
             abbreviated
         );
         this.populateRequestQueue(requestQueue, ownerDataCollection, githubToken);
+        const totalNumberOfRequests = requestQueue.getNumberOfRequests(); 
         let nextRequest: RequesteQueueEntry | undefined = requestQueue.popRequest();
         while (nextRequest) {
             await nextRequest.dataFetcher.process(
@@ -267,6 +268,8 @@ export class DependencyDetailsRetriever {
                 ownerDataCollection,
                 requestQueue
             );
+            const numberCompleted = totalNumberOfRequests - requestQueue.getNumberOfRequests();
+            TabDepthLogger.info(0, `Completed: ${numberCompleted} of ${totalNumberOfRequests}`);
             nextRequest = requestQueue.popRequest();
             await sleep(REQUEST_DELAY_MS);
         }

--- a/src/dependency-details-retriever.ts
+++ b/src/dependency-details-retriever.ts
@@ -127,7 +127,7 @@ type LanguageAndOpenIssuesCount = { language: string; openIssuesCount: number; a
 
 class RestfulLanguageAndIssuesDataFetcher extends BaseRestfulGithubDataFetcher<
     LanguageAndOpenIssuesCount
-    > {
+> {
     public executeRequest(params: RequestParams): Promise<LanguageAndOpenIssuesCount> {
         const requestUrl = this.getURL(params);
         TabDepthLogger.info(2, `Querying: ${requestUrl}`);
@@ -193,7 +193,7 @@ class RestfulLabelDataFetcher extends BaseRestfulGithubDataFetcher<object[]> {
     public executeRequest(params: RequestParams): Promise<object[]> {
         const requestUrl = `${this.getURL(params)}/issues?since=${MIN_ISSUE_DATE}&labels=${
             params.label
-            }`;
+        }`;
         TabDepthLogger.info(2, `Querying: ${requestUrl}`);
 
         return this.httpClient
@@ -280,6 +280,8 @@ export class DependencyDetailsRetriever {
             nextRequest = requestQueue.popRequest();
             await sleep(REQUEST_DELAY_MS);
         }
+        ownerDataCollection.save();
+        TabDepthLogger.info(0, 'Process complete! File saved');
     }
 
     private populateRequestQueue(

--- a/src/request-queue.ts
+++ b/src/request-queue.ts
@@ -40,6 +40,10 @@ export class RequestQueue {
         return request;
     }
 
+    public getNumberOfRequests(): number {
+        return this.requestQueue.getLength();
+    }
+
     private createKeyFromParams(params: RequestParams): string {
         const key = `${params.owner}'-'${params.repo}'-'${params.type}'-'${params.label}`;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,4 +30,8 @@ export class OrderedMap<K, V> {
 
         return undefined;
     }
+
+    public getLength(): number {
+        return this.ks.length;
+    }
 }


### PR DESCRIPTION
Implements a progress tracker that periodically (every 10 requests) logs how far along the analysis process is.
Adds some other logging and moves the file save.
Removes . from lint:fix script so it doesn't fix files in the dist folder.

This has been linted and run locally and appears to work correctly.