### PR TITLE
Bump version to 0.2.1-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-mariner",
-  "version": "0.2.0-alpha",
+  "version": "0.2.1-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "oss-mariner",
-    "version": "0.2.0-alpha",
+    "version": "0.2.1-alpha",
     "description": "A node.js library for analyzing open source library dependencies",
     "main": "dist/mariner/index.js",
     "types": "dist/mariner/index.d.ts",


### PR DESCRIPTION
Just a version number bump, so we can publish the new improved error handling. 