### PR TITLE
OSST-1114: logger should be optional

### DIFF
--- a/examples/runFasterCode.ts
+++ b/examples/runFasterCode.ts
@@ -14,7 +14,7 @@
 
 import fs from 'fs';
 import * as mariner from '../src/mariner/index'; // This is used during development
-// import * as mariner from 'oss-mariner'    // This is how the npm package would normally be used
+// import mariner from 'oss-mariner'    // This is how the npm package would normally be used
 
 import * as path from 'path';
 

--- a/examples/runFasterCode.ts
+++ b/examples/runFasterCode.ts
@@ -69,7 +69,7 @@ const repositoryLookupName = repositoryIdentifiers.map((identifier) => {
 });
 
 const labels = ['good first issue', 'help wanted', 'documentation'];
-const finder = new mariner.IssueFinder(logger);
+const finder = new mariner.IssueFinder();
 
 function convertToRecord(issues: Map<string, mariner.Issue[]>): void {
     const record: Record<string, mariner.Issue[]> = {};

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "oss-mariner",
     "version": "0.3.0-alpha",
     "description": "A node.js library for analyzing open source library dependencies",
-    "main": "dist/mariner/index.js",
-    "types": "dist/mariner/index.d.ts",
+    "main": "dist/src/mariner/index.js",
+    "types": "dist/src/mariner/index.d.ts",
     "author": "",
     "license": "Apache-2.0",
     "scripts": {

--- a/src/issueFinder.ts
+++ b/src/issueFinder.ts
@@ -9,12 +9,10 @@ export interface Issue {
 }
 
 export class IssueFinder {
-    private readonly logger: Logger;
     private readonly fetcher: GitHubIssueFetcher;
 
-    public constructor(logger: Logger) {
-        this.logger = logger;
-        this.fetcher = new GitHubIssueFetcher(logger);
+    public constructor() {
+        this.fetcher = new GitHubIssueFetcher();
     }
 
     public async findIssues(

--- a/src/mariner/index.ts
+++ b/src/mariner/index.ts
@@ -1,3 +1,3 @@
 export { DependencyDetailsRetriever } from '../dependency-details-retriever';
 export { Issue, IssueFinder } from '../issueFinder';
-export { Logger, setLogger } from '../tab-level-logger';
+export { Logger, getLogger, setLogger } from '../tab-level-logger';

--- a/src/tab-level-logger.ts
+++ b/src/tab-level-logger.ts
@@ -16,6 +16,10 @@ class ConsoleLogger implements Logger {
 
 let currentLogger = new ConsoleLogger();
 
+export function getLogger(): Logger {
+    return currentLogger;
+}
+
 export function setLogger(newLogger: Logger): void {
     currentLogger = newLogger;
 }


### PR DESCRIPTION
This avoids the requirement of passing a logger into the finder. Instead, the finder and fetcher just use the singleton logger, which runFasterCode sets by calling setLogger. 

For this to work, I changed the logger file to export a getLogger function. I exported that in mariner itself, in case the client wants to set a logger and immediately start using it via getLogger. 

This also fixes package.json to have the correct 'main' path. And it updates the commented-out line of code in runFasterCode.ts such that if you uncomment it, it will successfully import mariner and thus will be able to work. 