### PR TITLE
Jira/osst 1106

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 A node.js library for analyzing open source library dependencies.
 
-Mariner takes an input list of dependencies, fetches details about them from GitHub,
+Mariner's goal is to help you to support the open source projects you rely upon by making it easy to get a list of the open issues in your dependencies. 
+
+Mariner takes an input list of GitHub repos, fetches details about them from GitHub,
 and outputs a file containing a list of issues for each project.
 
 NOTE: This library is in the experimental stage, so expect breaking changes
@@ -29,19 +31,21 @@ When that tool is available, we plan to take full advantage of it.
 ## Getting Started Using Mariner
 
 If you just want to USE Mariner, you don't need to do a git clone.
-Instead, create your own new node project, and install the oss-mariner package via npm:
+Instead, you'll create your own new node project, and install the oss-mariner package via npm:
 `npm install oss-mariner`
+You'll also need a GitHub token and a config file. (Keep reading for more info on these.)
 
-### Step-by-step
+
+### Step-by-step Instructions for running Mariner
 
 1. Create a new project folder and use `npm init` to make it a node project.
-1. Copy the contents of `runFasterCode.ts` into `index.js` and copy `config.json`, `exampleData.json`
-   in the new project.
+1. Copy the contents of `runFasterCode.ts` into `index.js`.
     - <https://github.com/indeedeng/Mariner/blob/master/examples/runFasterCode.ts>
+1. In `index.js` comment out the existing line that imports mariner.
+1. Also in `index.js`, uncomment the line saying how mariner would normally be imported.
+1. Next, create a folder named `examples` and create two new files inside of it: `config.json` and `exampleData.json`. You can copy the contents of our examples into those new files or you can use the examples as a template for your own data and config choices. The `exampleData.json` should contain the repos that you're interested in getting issues from. You can use a full url or simply `orgname/reponame` for each repo. More info on the config.json can be found [here](https://github.com/indeedeng/Mariner/blob/master/README.md#config.json-format)
     - <https://github.com/indeedeng/Mariner/blob/master/examples/config.json>
     - <https://github.com/indeedeng/Mariner/blob/master/examples/exampleData.json>
-1. In `index.js` comment out the existing line that imports mariner.
-1. Also in `index.js` uncomment the line saying how mariner would normally be imported.
 1. Mariner supports TypeScript, but we don't have step-by-step instructions for the TypeScript example.
    For now, you can convert the runFasterCode.ts example code to JavaScript:
     - Remove the `public` keywords from class members.
@@ -49,7 +53,17 @@ Instead, create your own new node project, and install the oss-mariner package v
     - Remove all the type declarations (like `: string`).
 1. Run `npm install oss-mariner`
 1. Add `"type": "module"` to `package.json` to allow using "import" rather than "require".
-1. Run `node index.js`.
+1. Get a GitHub token. [See instructions here](https://github.com/indeedeng/Mariner#token)    
+1. Run `export MARINER_GITHUB_TOKEN={Insert your GitHub token here} node index.js`.
+
+### Config.json Format
+
+You can use our example config options as written, or customize the fields if you choose.
+-  numberOfReposPerCall: we recommend not changing this number. Unless you're getting an error from GitHub that your query string is too long, in which case try a smaller number.
+-  Every GitHub issue can have one or more labels attached to it. labelsToSearch is an array of the labels you'd like Mariner to search for in the issues it will return. The defaults in our example are ones that will make it easy for someone to make a first contribution to a repo. 
+-  make sure that your inputFilePath is accurate. If you followed the steps above and put `exampleData.json` into a top-level folder called `examples`, you won't have to change the value of this variable.
+-  outputFilePath is the place you'd like the results written to
+-  daysAgoCreated is for deciding how fresh you want the issues to be. If you only want issues that were created in the last week, then choose 7, for example. 
 
 ### Input File Format
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ Instead, you'll create your own new node project, and install the oss-mariner pa
 You'll also need a GitHub token and a config file. (Keep reading for more info on these.)
 
 
-### Step-by-step Instructions for running Mariner
+### Step-by-step instructions for creating a project that uses Mariner
 
 1. Create a new project folder and use `npm init` to make it a node project.
 1. Copy the contents of `runFasterCode.ts` into `index.js`.
     - <https://github.com/indeedeng/Mariner/blob/master/examples/runFasterCode.ts>
 1. In `index.js` comment out the existing line that imports mariner.
 1. Also in `index.js`, uncomment the line saying how mariner would normally be imported.
-1. Next, create a folder named `examples` and create two new files inside of it: `config.json` and `exampleData.json`. You can copy the contents of our examples into those new files or you can use the examples as a template for your own data and config choices. The `exampleData.json` should contain the repos that you're interested in getting issues from. You can use a full url or simply `orgname/reponame` for each repo. More info on the config.json can be found [here](https://github.com/indeedeng/Mariner/blob/master/README.md#config.json-format)
-    - <https://github.com/indeedeng/Mariner/blob/master/examples/config.json>
+1. Next, create a folder named `examples` and create two new files inside of it: `exampleData.json` and `config.json`. You can copy the contents of our examples into those new files or you can use the examples as a template for your own data and config choices. The `exampleData.json` should contain the repos that you're interested in getting issues from. For more info on the format of this file, look at[the Input File Format section](https://github.com/indeedeng/Mariner#input-file-format). More info on config.json can also be found [below](https://github.com/indeedeng/Mariner/blob/master/README.md#config.json-format) and the example files can be found here:
     - <https://github.com/indeedeng/Mariner/blob/master/examples/exampleData.json>
+    - <https://github.com/indeedeng/Mariner/blob/master/examples/config.json>
 1. Mariner supports TypeScript, but we don't have step-by-step instructions for the TypeScript example.
    For now, you can convert the runFasterCode.ts example code to JavaScript:
     - Remove the `public` keywords from class members.
@@ -53,17 +53,18 @@ You'll also need a GitHub token and a config file. (Keep reading for more info o
     - Remove all the type declarations (like `: string`).
 1. Run `npm install oss-mariner`
 1. Add `"type": "module"` to `package.json` to allow using "import" rather than "require".
-1. Get a GitHub token. [See instructions here](https://github.com/indeedeng/Mariner#token)    
-1. Run `export MARINER_GITHUB_TOKEN={Insert your GitHub token here} node index.js`.
+1. Get a GitHub token. [See instructions here](https://github.com/indeedeng/Mariner#token)
+1. Store your GitHub token in your system's environment by running `export MARINER_GITHUB_TOKEN={Insert your GitHub token here}`. You will either have to do this once each time you restart your system, or else configure your system to do so automatically.  
+1. Finally, run the application to find open issues in your dependencies, using the command `node index.js`.
 
 ### Config.json Format
 
 You can use our example config options as written, or customize the fields if you choose.
--  numberOfReposPerCall: we recommend not changing this number. Unless you're getting an error from GitHub that your query string is too long, in which case try a smaller number.
--  Every GitHub issue can have one or more labels attached to it. labelsToSearch is an array of the labels you'd like Mariner to search for in the issues it will return. The defaults in our example are ones that will make it easy for someone to make a first contribution to a repo. 
--  make sure that your inputFilePath is accurate. If you followed the steps above and put `exampleData.json` into a top-level folder called `examples`, you won't have to change the value of this variable.
--  outputFilePath is the place you'd like the results written to
--  daysAgoCreated is for deciding how fresh you want the issues to be. If you only want issues that were created in the last week, then choose 7, for example. 
+-  Every GitHub issue can have one or more labels attached to it. `labelsToSearch` is an array of the labels you'd like Mariner to search for in the issues it will return. The defaults in our example are ones that will make it easy for someone to make a first contribution to a repo. 
+-  Make sure that your `inputFilePath` is accurate. If you followed the steps above and put `exampleData.json` into a top-level folder called `examples`, you won't have to change the value of this variable.
+-  `outputFilePath` is the place you'd like the results written to
+-  `daysAgoCreated` is for deciding how fresh you want the issues to be. If you only want issues that were created in the last week, then choose 7, for example. 
+-  `numberOfReposPerCall`: we recommend not changing this number. Unless you're getting an error from GitHub that your query string is too long, in which case try a smaller number.
 
 ### Input File Format
 

--- a/examples/config.json
+++ b/examples/config.json
@@ -7,5 +7,5 @@
     ],
     "inputFilePath": "examples/exampleData.json",
     "outputFilePath": "examples/output.json",
-    "daysAgoCreated": null
+    "daysAgoCreated": 90
 }

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,5 +1,4 @@
 {
-    "numberOfReposPerCall": 1000,
     "labelsToSearch": [
         "good first issue",
         "help wanted",
@@ -7,5 +6,6 @@
     ],
     "inputFilePath": "examples/exampleData.json",
     "outputFilePath": "examples/output.json",
-    "daysAgoCreated": 90
+    "daysAgoCreated": 90,
+    "numberOfReposPerCall": 1000
 }

--- a/examples/runFasterCode.ts
+++ b/examples/runFasterCode.ts
@@ -28,8 +28,6 @@ function getFromEnvOrThrow(configField: string): string {
 }
 
 const token = getFromEnvOrThrow('MARINER_GITHUB_TOKEN');
-const inputFilePath = `${config.inputFilePath}`;
-const outputFilePath = `${config.outputFilePath}`;
 
 /*  This demonstrates instructing mariner to use a custom logger.
     It is optional, and if you don't call setLogger,
@@ -47,10 +45,11 @@ class FancyLogger implements mariner.Logger {
 const logger = new FancyLogger();
 mariner.setLogger(logger);
 
-logger.info(`Input:  ${path.resolve(inputFilePath)}`);
-logger.info(`Output: ${path.resolve(outputFilePath)}`);
+logger.info(`Input:  ${path.resolve(config.inputFilePath)}`);
+logger.info(`Output: ${path.resolve(config.outputFilePath)}`);
+logger.info(`Fetching issues from the last ${config.daysAgoCreated} days`);
 
-const contents = fs.readFileSync(inputFilePath, {
+const contents = fs.readFileSync(config.inputFilePath, {
     encoding: 'utf8',
 });
 
@@ -81,7 +80,7 @@ function outputToJson(record: Record<string, mariner.Issue[]>): void {
     const noReplacer = undefined;
     const indent = 2;
     const jsonResults = JSON.stringify(record, noReplacer, indent);
-    const data = fs.writeFileSync(outputFilePath, jsonResults);
+    const data = fs.writeFileSync(config.outputFilePath, jsonResults);
 
     return data;
 }
@@ -96,7 +95,7 @@ finder
 
         convertToRecord(issues);
         logger.info(`Found ${issueCount} issues in ${issues.size} projects\n`);
-        logger.info(`Saved issue results to: ${outputFilePath}`);
+        logger.info(`Saved issue results to: ${config.outputFilePath}`);
     })
     .catch((err) => {
         logger.error(err.message);

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,15 +5,34 @@ export interface Config {
     numberOfReposPerCall: number;
     inputFilePath: string;
     outputFilePath: string;
-    daysAgoCreated?: number;
+    daysAgoCreated: number;
 }
 
-export function readConfigFile(filePath: string): Config {
-    const configFilePath = `${filePath}`;
+export function readConfigFile(configFilePath: string): Config {
     const configJSON = fs.readFileSync(configFilePath, {
         encoding: 'utf8',
     });
-    const entireConfig = JSON.parse(configJSON) as Config;
+    const rawConfig = JSON.parse(configJSON);
+
+    const daysAgoCreated = getValidDaysAgoCreated(rawConfig.daysAgoCreated);
+
+    const entireConfig: Config = {
+        labelsToSearch: rawConfig.labelsToSearch,
+        numberOfReposPerCall: rawConfig.numberOfReposPerCall,
+        inputFilePath: rawConfig.inputFilePath,
+        outputFilePath: rawConfig.outputFilePath,
+        daysAgoCreated: daysAgoCreated,
+    };
 
     return entireConfig;
+}
+
+function getValidDaysAgoCreated(rawDaysAgoCreated: number): number {
+    if (rawDaysAgoCreated >= 0) {
+        return rawDaysAgoCreated;
+    }
+
+    const defaultNumberOfDays = 90;
+
+    return defaultNumberOfDays;
 }

--- a/src/gitHubIssueFetcher.ts
+++ b/src/gitHubIssueFetcher.ts
@@ -100,14 +100,14 @@ export class GitHubIssueFetcher {
         const pageSize = 100;
         const numberOfReposPerCall = this.config.numberOfReposPerCall;
         const reposForEachCall = this.splitArray(repositoryIdentifiers, numberOfReposPerCall);
-        const daysAgoCreated = this.config.daysAgoCreated || 90;
-        const DateStringForQuery = DateTime.local().minus({ days: daysAgoCreated }).toISODate();
+        const daysAgoCreated = this.config.daysAgoCreated;
+        const dateTimeStringForQuery = DateTime.local().minus({ days: daysAgoCreated }).toISO();
 
         const edgeArray: Edge[] = [];
         for (const chunk of reposForEachCall) {
             const listOfRepos = this.createListOfRepos(chunk);
             const variables: Variables = {
-                queryString: `label:"${label}" state:open ${listOfRepos} created:>${DateStringForQuery}`,
+                queryString: `label:"${label}" state:open ${listOfRepos} created:>${dateTimeStringForQuery}`,
                 pageSize,
             };
             const queryId = `${label}: ${chunk[0]}`;


### PR DESCRIPTION
This PR completes the work making a daysAgoCreated config variable to confine issue results to those that were created after a point in time. Part of this was merged in already, this piece:
a) makes sure that the value we get from daysAgoCreated is handled correctly
b) updates the README for clarity and with info about the config.js

Questions for @kevindigo :
- There may be better instructions for how to export the Github token?
- I believe `config.json` and `exampleData.json` have to be in a folder called examples for the paths to work (so I added that to the instructions) - is that correct?
- A config.json question: What happens if there are no labels specified? What if they want all open issues, regardless of label? Is that possible?