### PR TITLE
Issue 51: Adding updatedAt and labels to the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Run `npm run build` to compile the code to Javascript.
 
 Run `node dist/examples/runFasterCode.js` (to use GraphQL) or `node dist/examples/runOldCode.ts` (to use REST calls), to run the example program. It requires internet access, since it calls the GitHub API. It will take a couple minutes to complete. Some of the output includes the word "ERROR", so don't panic.
 
+Ensure to lint your code by running `npm run lint` before submitting any code for review. `npm run lint:fix` will automatically fix any errors.
+
 ## Local testing of the npm packaging
 
 You should have local copies of both the oss-mariner project and the project that will include it.

--- a/README.md
+++ b/README.md
@@ -81,9 +81,50 @@ The input file is a JSON file in the format:
 ### Output File Format
 
 The output file is a JSON file in the format:
+```javascript
+{
+  "repository/name": [
+    {
+      "title": "Issue Title 1",
+      "createdAt": "2020-10-16T01:07:36Z",
+      "repositoryNameWithOwner": "repository/name",
+      "url": "https://github.com/repository/name/issues/65",
+      "updatedAt": "2020-10-16T01:07:36Z",
+      "labels": [
+        "Hacktoberfest",
+        "good first issue"
+      ]
+    },
+    {
+      "title": "Issue Title 2",
+      "createdAt": "2020-10-12T22:37:17Z",
+      "repositoryNameWithOwner": "repository/name",
+      "url": "https://github.com/repository/name/issues/58",
+      "updatedAt": "2020-10-12T22:37:17Z",
+      "labels": [
+        "Hacktoberfest",
+        "good first issue"
+      ]
+    }
+  ],
+  "respository/second_name": [
+    {
+      "title": "Issue 102",
+      "createdAt": "2020-10-03T13:16:58Z",
+      "repositoryNameWithOwner": "respository/second_name",
+      "url": "https://github.com/respository/second_name/issues/12137",
+      "updatedAt": "2020-10-03T13:16:58Z",
+      "labels": [
+        "claimed",
+        "good first issue",
+        "i: enhancement"
+      ]
+    }
+  ],
+}
+```
 
--   (We'll add a definition of the format later.
-    For now, you can look at examples/output.json after running the app)
+Please note that only the first 100 labels per issue will be fetched. If a single issue has over 100 labels, these will be excluded without any errors or warnings.
 
 ## Token
 

--- a/src/gitHubIssueFetcher.ts
+++ b/src/gitHubIssueFetcher.ts
@@ -37,6 +37,8 @@ export interface GitHubIssue {
     createdAt: string;
     repository: GitHubRepository;
     url: string;
+    updatedAt: string;
+    labels: { edges: Array<{ node: { name: string}}> };
 }
 
 interface GitHubRepository {
@@ -68,6 +70,14 @@ query findByLabel($queryString:String!, $pageSize:Int, $after:String) {
                         nameWithOwner
                     }
                     url
+                    updatedAt
+                    labels(first: $pageSize) {
+                        edges{
+                            node{
+                                name
+                            }
+                        }
+                    }
     	        }
             }
         }

--- a/src/gitHubIssueFetcher.ts
+++ b/src/gitHubIssueFetcher.ts
@@ -45,10 +45,10 @@ interface GitHubRepository {
     nameWithOwner: string;
 }
 
-export interface GitHubLabelEdge { 
+export interface GitHubLabelEdge {
     node: {
-        name: string
-    }
+        name: string;
+    };
 }
 
 interface Variables extends RequestParameters {

--- a/src/gitHubIssueFetcher.ts
+++ b/src/gitHubIssueFetcher.ts
@@ -38,21 +38,28 @@ export interface GitHubIssue {
     repository: GitHubRepository;
     url: string;
     updatedAt: string;
-    labels: { edges: Array<{ node: { name: string}}> };
+    labels: { edges: GitHubLabelEdge[] };
 }
 
 interface GitHubRepository {
     nameWithOwner: string;
 }
 
+export interface GitHubLabelEdge { 
+    node: {
+        name: string
+    }
+}
+
 interface Variables extends RequestParameters {
     queryString: string;
     pageSize: number;
+    maxLabelsToRetrieve: number;
     after?: string;
 }
 
 const queryTemplate = `
-query findByLabel($queryString:String!, $pageSize:Int, $after:String) {
+query findByLabel($queryString:String!, $pageSize:Int, $maxLabelsToRetrieve:Int, $after:String) {
     search(
         type: ISSUE, 
         query: $queryString
@@ -71,7 +78,7 @@ query findByLabel($queryString:String!, $pageSize:Int, $after:String) {
                     }
                     url
                     updatedAt
-                    labels(first: $pageSize) {
+                    labels(first: $maxLabelsToRetrieve) {
                         edges{
                             node{
                                 name
@@ -108,6 +115,7 @@ export class GitHubIssueFetcher {
         repositoryIdentifiers: string[]
     ): Promise<GitHubIssue[]> {
         const pageSize = 100;
+        const maxLabelsToRetrieve = 100;
         const numberOfReposPerCall = this.config.numberOfReposPerCall;
         const reposForEachCall = this.splitArray(repositoryIdentifiers, numberOfReposPerCall);
         const daysAgoCreated = this.config.daysAgoCreated;
@@ -119,6 +127,7 @@ export class GitHubIssueFetcher {
             const variables: Variables = {
                 queryString: `label:"${label}" state:open ${listOfRepos} created:>${dateTimeStringForQuery}`,
                 pageSize,
+                maxLabelsToRetrieve,
             };
             const queryId = `${label}: ${chunk[0]}`;
             const issue = await this.fetchAllPages(token, queryTemplate, variables, queryId);

--- a/src/issueFinder.ts
+++ b/src/issueFinder.ts
@@ -6,6 +6,8 @@ export interface Issue {
     createdAt: string;
     repositoryNameWithOwner: string;
     url: string;
+    updatedAt: string;
+    labels: string[];
 }
 
 export class IssueFinder {
@@ -56,9 +58,18 @@ export class IssueFinder {
             createdAt: node.createdAt,
             repositoryNameWithOwner: node.repository.nameWithOwner,
             url: node.url,
+            updatedAt: node.createdAt,
+            labels: this.convertFromGitHubLabels(node.labels.edges)
         };
 
         return issue;
+    }
+
+    private convertFromGitHubLabels(edges: Array<{ node: { name: string}}>) {
+        const labels = edges.reduce((labels: string[], edge) => {
+            return[...labels, edge.node.name]
+        }, [])
+        return labels;
     }
 
     private omitDuplicates(issues: Issue[]): Issue[] {

--- a/src/issueFinder.ts
+++ b/src/issueFinder.ts
@@ -59,7 +59,7 @@ export class IssueFinder {
             repositoryNameWithOwner: node.repository.nameWithOwner,
             url: node.url,
             updatedAt: node.updatedAt,
-            labels: this.convertFromGitHubLabels(node.labels.edges)
+            labels: this.convertFromGitHubLabels(node.labels.edges),
         };
 
         return issue;
@@ -68,7 +68,8 @@ export class IssueFinder {
     private convertFromGitHubLabels(edges: GitHubLabelEdge[]) {
         const labels = edges.map((edge) => {
             return edge.node.name;
-        })
+        });
+
         return labels;
     }
 

--- a/src/issueFinder.ts
+++ b/src/issueFinder.ts
@@ -1,4 +1,4 @@
-import { GitHubIssueFetcher, GitHubIssue } from './gitHubIssueFetcher';
+import { GitHubIssueFetcher, GitHubIssue, GitHubLabelEdge } from './gitHubIssueFetcher';
 import { Config } from './config';
 
 export interface Issue {
@@ -58,17 +58,17 @@ export class IssueFinder {
             createdAt: node.createdAt,
             repositoryNameWithOwner: node.repository.nameWithOwner,
             url: node.url,
-            updatedAt: node.createdAt,
+            updatedAt: node.updatedAt,
             labels: this.convertFromGitHubLabels(node.labels.edges)
         };
 
         return issue;
     }
 
-    private convertFromGitHubLabels(edges: Array<{ node: { name: string}}>) {
-        const labels = edges.reduce((labels: string[], edge) => {
-            return[...labels, edge.node.name]
-        }, [])
+    private convertFromGitHubLabels(edges: GitHubLabelEdge[]) {
+        const labels = edges.map((edge) => {
+            return edge.node.name;
+        })
         return labels;
     }
 


### PR DESCRIPTION
Updated the graphQL query to grab createdAt and all labels (I defaulted to 100, but didn't do another page grab). Not sure if y'all want to limit the number of labels fetched or not, but I would be worried if a ticket had more than 100. 

Updated the output to include and array of strings for the labels (with just the label name) and the createdAt field