### PR TITLE
Implement HTML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A node.js library for analyzing open source library dependencies.
 
-Mariner's goal is to help you to support the open source projects you rely upon by making it easy to get a list of the open issues in your dependencies. 
+Mariner's goal is to help you to support the open source projects you rely upon by making it easy to get a list of the open issues in your dependencies.
 
 Mariner takes an input list of GitHub repos, fetches details about them from GitHub,
 and outputs a file containing a list of issues for each project.
@@ -32,7 +32,6 @@ Instead, you'll create your own new node project, and install the oss-mariner pa
 `npm install oss-mariner`
 You'll also need a GitHub token and a config file. (Keep reading for more info on these.)
 
-
 ### Step-by-step instructions for creating a project that uses Mariner
 
 1. Create a new project folder and use `npm init` to make it a node project.
@@ -55,12 +54,14 @@ You'll also need a GitHub token and a config file. (Keep reading for more info o
 1. Finally, run the application to find open issues in your dependencies, using the command `node index.js`.
 
 ### Optional: Generating Markdown
+
 - You can generate markdown for use in Confluence/jira
 - The generateConfluenceMarkdown() creates the markdown based on two parameters: `maxIssuesAge` and `issuesByDependency`
 - `maxIssueAge` defaults to 30 days, anything over 30 days won't get written, You can edit this number.
 - Square brackets and curly braces in issue titles will be replaced by parentheses.
 - You can see an example of how to use in the `runExample.ts` file.
 Example of confluenceMarkdown.md output:
+
 ```md
 ## Updated: February 22, 2021, 5:38 PM PST
 
@@ -74,33 +75,36 @@ h3. facebook/jest
 ||*Title*||*Age*||
 |[Lost of context between tests when using dynamic ESM import|https://github.com/facebook/jest/issues/10944]|72&nbsp;days|
 ```
+
 - The `runExample.ts` example now demonstrates how to call this new function
-    - <https://github.com/indeedeng/Mariner/blob/master/examples/runExample.ts>
+  - <https://github.com/indeedeng/Mariner/blob/master/examples/runExample.ts>
 
 ### Config.json Format
 
 You can use our example config options as written, or customize the fields if you choose.
--  Every GitHub issue can have one or more labels attached to it. `labelsToSearch` is an array of the labels you'd like Mariner to search for in the issues it will return. The defaults in our example are ones that will make it easy for someone to make a first contribution to a repo. 
--  Make sure that your `inputFilePath` is accurate. If you followed the steps above and put `exampleData.json` into a top-level folder called `examples`, you won't have to change the value of this variable.
--  `outputFilePath` is the place you'd like the results written to
--  `daysAgoCreated` is for deciding how fresh you want the issues to be. If you only want issues that were created in the last week, then choose 7, for example. 
--  `numberOfReposPerCall`: we recommend not changing this number. Unless you're getting an error from GitHub that your query string is too long, in which case try a smaller number.
+
+- Every GitHub issue can have one or more labels attached to it. `labelsToSearch` is an array of the labels you'd like Mariner to search for in the issues it will return. The defaults in our example are ones that will make it easy for someone to make a first contribution to a repo.
+- Make sure that your `inputFilePath` is accurate. If you followed the steps above and put `exampleData.json` into a top-level folder called `examples`, you won't have to change the value of this variable.
+- `outputFilePath` is the place you'd like the results written to
+- `daysAgoCreated` is for deciding how fresh you want the issues to be. If you only want issues that were created in the last week, then choose 7, for example.
+- `numberOfReposPerCall`: we recommend not changing this number. Unless you're getting an error from GitHub that your query string is too long, in which case try a smaller number.
 
 ### Input File Format
 
 The input file is a JSON file in the format:
 
--   At the top level is a map/object, where each entry consists of a dependency as the key,
+- At the top level is a map/object, where each entry consists of a dependency as the key,
     and the number of projects that depend on that library as the value.
--   Each dependency can be identified by a complete URL or just the owner/repo string.
--   Example complete url: "https://api.github.com/repos/spring-projects/spring-framework": 19805,
--   Example owner/repo strings: "square/retrofit": 5023,
--   The project count value is mostly ignored, but is used by the "abbreviated" feature.
--   See examples/exampleData.json for a complete example.
+- Each dependency can be identified by a complete URL or just the owner/repo string.
+- Example complete url: "https://api.github.com/repos/spring-projects/spring-framework": 19805,
+- Example owner/repo strings: "square/retrofit": 5023,
+- The project count value is mostly ignored, but is used by the "abbreviated" feature.
+- See examples/exampleData.json for a complete example.
 
 ### Output File Format
 
 The output file is a JSON file in the format:
+
 ```javascript
 {
   "repository/name": [

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ even if the version number does not indicate that.
 The first couple alpha versions of Mariner only supported calls via GitHub's REST API. More
 recently, we added the ability to invoke GitHub's GraphQL API. The GraphQL API is hundreds of
 times faster, so the REST-related calls are now deprecated, and will be removed "soon". The
-GraphQL approach is shown in the `runFasterCode.ts` example.
+GraphQL approach is shown in the `runExample.ts` example.
 
 ### Plans to rename the default branch from master
 
@@ -36,15 +36,15 @@ You'll also need a GitHub token and a config file. (Keep reading for more info o
 ### Step-by-step instructions for creating a project that uses Mariner
 
 1. Create a new project folder and use `npm init` to make it a node project.
-1. Copy the contents of `runFasterCode.ts` into `index.js`.
-    - <https://github.com/indeedeng/Mariner/blob/master/examples/runFasterCode.ts>
+1. Copy the contents of `runExample.ts` into `index.js`.
+    - <https://github.com/indeedeng/Mariner/blob/master/examples/runExample.ts>
 1. In `index.js` comment out the existing line that imports mariner.
 1. Also in `index.js`, uncomment the line saying how mariner would normally be imported.
 1. Next, create a folder named `examples` and create two new files inside of it: `exampleData.json` and `config.json`. You can copy the contents of our examples into those new files or you can use the examples as a template for your own data and config choices. The `exampleData.json` should contain the repos that you're interested in getting issues from. For more info on the format of this file, look at[the Input File Format section](https://github.com/indeedeng/Mariner#input-file-format). More info on config.json can also be found [below](https://github.com/indeedeng/Mariner/blob/master/README.md#config.json-format) and the example files can be found here:
     - <https://github.com/indeedeng/Mariner/blob/master/examples/exampleData.json>
     - <https://github.com/indeedeng/Mariner/blob/master/examples/config.json>
 1. Mariner supports TypeScript, but we don't have step-by-step instructions for the TypeScript example.
-   For now, you can convert the runFasterCode.ts example code to JavaScript:
+   For now, you can convert the runExample.ts example code to JavaScript:
     - Remove the `public` keywords from class members.
     - Remove the `implements Xxxx` from the FancyLogger class declaration.
     - Remove all the type declarations (like `: string`).
@@ -59,7 +59,7 @@ You'll also need a GitHub token and a config file. (Keep reading for more info o
 - The generateConfluenceMarkdown() creates the markdown based on two parameters: `maxIssuesAge` and `issuesByDependency`
 - `maxIssueAge` defaults to 30 days, anything over 30 days won't get written, You can edit this number.
 - Square brackets and curly braces in issue titles will be replaced by parentheses.
-- You can see an example of how to use in the `runFasterCode.ts` file.
+- You can see an example of how to use in the `runExample.ts` file.
 Example of confluenceMarkdown.md output:
 ```md
 ## Updated: February 22, 2021, 5:38 PM PST
@@ -74,8 +74,8 @@ h3. facebook/jest
 ||*Title*||*Age*||
 |[Lost of context between tests when using dynamic ESM import|https://github.com/facebook/jest/issues/10944]|72&nbsp;days|
 ```
-- The `runFasterCode.ts` example now demonstrates how to call this new function
-    - <https://github.com/indeedeng/Mariner/blob/master/examples/runFasterCode.ts>
+- The `runExample.ts` example now demonstrates how to call this new function
+    - <https://github.com/indeedeng/Mariner/blob/master/examples/runExample.ts>
 
 ### Config.json Format
 
@@ -163,7 +163,7 @@ Mariner is in transition from the old way of accessing GitHub data (REST) to the
 
 To invoke mariner using the new GraphQL code, Invoke the finder(), passing the
 appropiate parameters in finder.findIssues() you can see an example here:
-<https://github.com/indeedeng/Mariner/blob/master/examples/runFasterCode.ts>
+<https://github.com/indeedeng/Mariner/blob/master/examples/runExample.ts>
 
 If you are using the `examples/runOldCode.ts file`, (using the old REST code that is very slow)
 invoke the DependencyDetailsRetriever.run() method, passing appropriate parameters. Please
@@ -190,13 +190,13 @@ Clone the repository from GitHub.
 
 Run `npm ci` to install the libraries used in the project. Read more about [npm ci here.](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable)
 
-Follow the instructions in examples/runFasterCode.ts or examples/runOldCode.ts to configure the input and output files. NOTE: An example input file is included, in the examples directory.
+Follow the instructions in examples/runExample.ts or examples/runOldCode.ts to configure the input and output files. NOTE: An example input file is included, in the examples directory.
 
 Run `nvm use` to use the appropiate version of Node specified in the .nvmrc file.
 
 Run `npm run build` to compile the code to Javascript.
 
-Run `node dist/examples/runFasterCode.js` (to use GraphQL) or `node dist/examples/runOldCode.ts` (to use REST calls), to run the example program. It requires internet access, since it calls the GitHub API. It will take a couple minutes to complete. Some of the output includes the word "ERROR", so don't panic.
+Run `node dist/examples/runExample.js` (to use GraphQL) or `node dist/examples/runOldCode.ts` (to use REST calls), to run the example program. It requires internet access, since it calls the GitHub API. It will take a couple minutes to complete. Some of the output includes the word "ERROR", so don't panic.
 
 Ensure to lint your code by running `npm run lint` before submitting any code for review. Either manually fix the errors or run `npm run lint:fix` to automatically fix any errors.
 

--- a/examples/runExample.ts
+++ b/examples/runExample.ts
@@ -6,7 +6,7 @@
     Optionally, you can have environment variables for INPUT_FILE_PATH and OUTPUT_FILE_PATH,
         but they have defaults that will work with the standard development environment.
     Then, run `npm run build`
-    Finally, run `node dist/examples/runFasterCode.js`
+    Finally, run `node dist/examples/runExample.js`
 
     You'll know it's run correctly if you have a new file
         examples/output.json with some GitHub issues in it.

--- a/examples/runExample.ts
+++ b/examples/runExample.ts
@@ -19,8 +19,6 @@ import * as path from 'path';
 const config = mariner.readConfigFile('examples/config.json');
 
 const htmlPath = 'examples/output.html';
-// NOTE: Confluence output is disabled here by default, because HTML is usually preferred
-// const confluenceMarkdownPath = 'examples/confluenceMarkdown.md';
 
 function getFromEnvOrThrow(configField: string): string {
     const value = process.env[configField];
@@ -101,12 +99,6 @@ finder
         const html = mariner.generateHtml(issues, 90);
         fs.writeFileSync(htmlPath, html);
         logger.info(`Saved HTML to: ${htmlPath}`);
-
-        // NOTE: Confluence output is disabled here by default, because HTML is usually preferred
-        // const confluenceMarkdown = mariner.generateConfluenceMarkdown(issues);
-        // console.log(confluenceMarkdown);
-        // fs.writeFileSync(confluenceMarkdownPath, confluenceMarkdown);
-        // logger.info(`Saved Confluence Markdown to: ${confluenceMarkdownPath}`);
     })
     .catch((err) => {
         logger.error(err.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2861,6 +2861,11 @@
                 "whatwg-encoding": "^1.0.5"
             }
         },
+        "html-entities": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+            "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
+        },
         "html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@octokit/graphql": "^4.6.1",
         "@types/luxon": "^1.26.2",
         "@types/node-fetch": "^2.5.8",
+        "html-entities": "^2.3.2",
         "luxon": "^1.26.0",
         "node-fetch": "^2.6.1"
     },

--- a/src/Utilities/generateHtml.ts
+++ b/src/Utilities/generateHtml.ts
@@ -1,0 +1,44 @@
+import { encode } from 'html-entities';
+import { DateTime } from 'luxon';
+import { Issue } from '../issueFinder';
+import { calculateAgeInWholeDays } from './generateConfluenceMarkdown';
+
+export function generateHtml(issuesByDependency: Map<string, Issue[]>, maxIssuesAge = 30): string {
+    const now = DateTime.utc();
+
+    const arrayOfHtmlFragments: string[] = [];
+
+    for (const [dependency, issues] of issuesByDependency) {
+        if (!issues || !issues.length) {
+            continue;
+        }
+
+        const relevantIssues = issues.filter((issue) => {
+            const ageInWholeDays = calculateAgeInWholeDays(issue.createdAt, now);
+
+            return ageInWholeDays < maxIssuesAge;
+        });
+
+        if (!relevantIssues.length) {
+            continue;
+        }
+
+        const dependencyName = encode(dependency);
+        arrayOfHtmlFragments.push(`<h3>${dependencyName}</h3>`);
+        arrayOfHtmlFragments.push('<table><tr><th>Title</th><th>Age</th></tr>');
+
+        relevantIssues.forEach((issue) => {
+            const ageInWholeDays = calculateAgeInWholeDays(issue.createdAt, now);
+
+            const title = encode(issue.title);
+            const url = encode(issue.url);
+            arrayOfHtmlFragments.push(
+                `<tr><td><a href="${url}">${title}</a></td><td>${ageInWholeDays}&nbsp;days</td></tr>`
+            );
+        });
+
+        arrayOfHtmlFragments.push('</table>');
+    }
+
+    return arrayOfHtmlFragments.join('\n');
+}

--- a/src/Utilities/generateHtml.ts
+++ b/src/Utilities/generateHtml.ts
@@ -23,22 +23,41 @@ export function generateHtml(issuesByDependency: Map<string, Issue[]>, maxIssues
             continue;
         }
 
-        const dependencyName = encode(dependency);
-        arrayOfHtmlFragments.push(`<h3>${dependencyName}</h3>`);
-        arrayOfHtmlFragments.push('<table><tr><th>Title</th><th>Age</th></tr>');
-
-        relevantIssues.forEach((issue) => {
-            const ageInWholeDays = calculateAgeInWholeDays(issue.createdAt, now);
-
-            const title = encode(issue.title);
-            const url = encode(issue.url);
-            arrayOfHtmlFragments.push(
-                `<tr><td><a href="${url}">${title}</a></td><td>${ageInWholeDays}&nbsp;days</td></tr>`
-            );
-        });
-
-        arrayOfHtmlFragments.push('</table>');
+        const fragmentsForDependency = generateHtmlFragmentsForDependency(
+            dependency,
+            relevantIssues,
+            now
+        );
+        arrayOfHtmlFragments.push(...fragmentsForDependency);
     }
 
     return arrayOfHtmlFragments.join('\n');
+}
+
+function generateHtmlFragmentsForDependency(
+    dependencyName: string,
+    relevantIssues: Issue[],
+    now: DateTime
+): string[] {
+    const arrayOfHtmlFragments: string[] = [];
+
+    const encodedDependencyName = encode(dependencyName);
+    arrayOfHtmlFragments.push(`<h3 class="dependency-name">${encodedDependencyName}</h3>`);
+    arrayOfHtmlFragments.push('<table class="issue-list">');
+    arrayOfHtmlFragments.push('<tr class="issue-header-row"><th>Title</th><th>Age</th></tr>');
+
+    relevantIssues.forEach((issue) => {
+        const ageInWholeDays = calculateAgeInWholeDays(issue.createdAt, now);
+
+        const title = encode(issue.title);
+        const url = encode(issue.url);
+        arrayOfHtmlFragments.push('<tr class="issue-row">');
+        arrayOfHtmlFragments.push(`<td class="issue-title"><a href="${url}">${title}</a></td>`);
+        arrayOfHtmlFragments.push(`<td class="issue-age">${ageInWholeDays}&nbsp;days</td>`);
+        arrayOfHtmlFragments.push('</tr>');
+    });
+
+    arrayOfHtmlFragments.push('</table>');
+
+    return arrayOfHtmlFragments;
 }

--- a/src/__tests__/generateHtml.test.ts
+++ b/src/__tests__/generateHtml.test.ts
@@ -1,0 +1,130 @@
+import * as mariner from '../mariner/index';
+import { Issue } from '../issueFinder';
+import { DateTime, Duration } from 'luxon';
+import { encode } from 'html-entities';
+
+const eightDaysAgo = DateTime.utc().minus(Duration.fromISO('P8D')).toISO();
+const twoDaysAgo = DateTime.utc().minus(Duration.fromISO('P2D')).toISO();
+const maxAgeInDays = 30;
+
+const fakeIssues: Issue[] = [
+    {
+        title: 'Formatting seems to use Prettier options by default',
+        createdAt: eightDaysAgo,
+        repositoryNameWithOwner: 'bc/typescript',
+        url: 'https://github.com/bc/typescript/issues/30',
+        updatedAt: '',
+        labels: ['help wanted', 'documentation'],
+    },
+
+    {
+        title: 'style config',
+        createdAt: eightDaysAgo,
+        repositoryNameWithOwner: 'material-ui/mui',
+        url: 'https://github.com/material-ui/issues/24',
+        updatedAt: '',
+        labels: ['good first issue', 'help wanted', 'documentation'],
+    },
+];
+
+const singleIssue: Issue[] = [
+    {
+        title: 'ToC: links to markdown headings',
+        createdAt: eightDaysAgo,
+        repositoryNameWithOwner: 'marmelab/react-admin',
+        url: 'https://github.com/marmelab/react-admin/issues/5620',
+        updatedAt: twoDaysAgo,
+        labels: ['good first issue', 'documentation'],
+    },
+];
+
+describe('generateHtml function', () => {
+    it('should properly format a dependency with an issue', () => {
+        const mockDependencyMap: Map<string, Issue[]> = new Map();
+        const dependency = 'Babel';
+
+        mockDependencyMap.set(dependency, singleIssue);
+
+        const results = mariner.generateHtml(mockDependencyMap, maxAgeInDays);
+        expect(results).toContain(`<h3>${dependency}</h3>`);
+        expect(results).toContain('<table><tr><th>Title</th><th>Age</th></tr>');
+        const issue = singleIssue[0];
+        const titleCellContents = `<a href="${encode(issue.url)}">${encode(issue.title)}</a>`;
+        const ageCellContents = '8&nbsp;days';
+        expect(results).toContain(
+            `<tr><td>${titleCellContents}</td><td>${ageCellContents}</td></tr>`
+        );
+        expect(results).toContain('</table>');
+    });
+
+    it('should include both issues for a dependency', () => {
+        const mockDependencyMap: Map<string, Issue[]> = new Map();
+        const dependency = 'NodeJsDependency';
+
+        const twoIssues = mockDependencyMap.set(dependency, fakeIssues);
+        const results = mariner.generateHtml(twoIssues, maxAgeInDays);
+
+        expect(results).toContain(dependency);
+        expect(results).toContain(encode(fakeIssues[0].title));
+        expect(results).toContain(encode(fakeIssues[0].url));
+        expect(results).toContain(encode(fakeIssues[1].title));
+        expect(results).toContain(encode(fakeIssues[1].url));
+    });
+
+    it('should include both dependencies that have issues', () => {
+        const mockDependencyMap: Map<string, Issue[]> = new Map();
+        const dependency1 = 'Graphql';
+        const dependency2 = 'TypeStrong';
+
+        mockDependencyMap.set(dependency1, fakeIssues);
+        mockDependencyMap.set(dependency2, singleIssue);
+
+        const results = mariner.generateHtml(mockDependencyMap, maxAgeInDays);
+
+        expect(results).toContain(dependency1);
+        expect(results).toContain(encode(fakeIssues[0].title));
+        expect(results).toContain(encode(fakeIssues[0].url));
+        expect(results).toContain(encode(fakeIssues[1].title));
+        expect(results).toContain(encode(fakeIssues[1].url));
+
+        expect(results).toContain(dependency2);
+        expect(results).toContain(encode(singleIssue[0].title));
+        expect(results).toContain(encode(singleIssue[0].url));
+    });
+
+    it('should not generate the dependencies table if there are no issues', () => {
+        const issuesByDependency: Map<string, Issue[]> = new Map();
+        const noIssues: Issue[] = [];
+        const dependency = 'TestDependency';
+
+        const oneDependencyNoIssue = issuesByDependency.set(dependency, noIssues);
+        const results = mariner.generateHtml(oneDependencyNoIssue, maxAgeInDays);
+        expect(results).not.toContain(dependency);
+        expect(results).not.toContain('Title');
+        expect(results).not.toContain('Age');
+        expect(results).not.toContain('days');
+    });
+
+    it('should handle special characters in an issue title', () => {
+        const mockDependencyMap: Map<string, Issue[]> = new Map();
+        const dependency = 'React';
+        singleIssue[0].title =
+            '[Navigation Editor] Dropdown & menus too narrow {braces} <angle brackets>';
+
+        mockDependencyMap.set(dependency, singleIssue);
+        const results = mariner.generateHtml(mockDependencyMap, maxAgeInDays);
+
+        expect(results).not.toContain(singleIssue[0].title);
+        expect(results).toContain(encode(singleIssue[0].title));
+    });
+
+    it('should not list a dependency with no issues if its issue is too old', () => {
+        const mockDependencyMap: Map<string, Issue[]> = new Map();
+        const dependency = 'Badges/shields';
+        singleIssue[0].createdAt = '2021-01-02T10:22:41Z'; // old issue
+
+        mockDependencyMap.set(dependency, singleIssue);
+        const results = mariner.generateHtml(mockDependencyMap, maxAgeInDays);
+        expect(results).not.toContain(dependency);
+    });
+});

--- a/src/__tests__/generateHtml.test.ts
+++ b/src/__tests__/generateHtml.test.ts
@@ -46,13 +46,14 @@ describe('generateHtml function', () => {
         mockDependencyMap.set(dependency, singleIssue);
 
         const results = mariner.generateHtml(mockDependencyMap, maxAgeInDays);
-        expect(results).toContain(`<h3>${dependency}</h3>`);
-        expect(results).toContain('<table><tr><th>Title</th><th>Age</th></tr>');
+        expect(results).toContain(`<h3 class="dependency-name">${dependency}</h3>\n`);
+        expect(results).toContain('<table class="issue-list">\n');
+        expect(results).toContain('<tr class="issue-header-row"><th>Title</th><th>Age</th></tr>\n');
         const issue = singleIssue[0];
         const titleCellContents = `<a href="${encode(issue.url)}">${encode(issue.title)}</a>`;
         const ageCellContents = '8&nbsp;days';
         expect(results).toContain(
-            `<tr><td>${titleCellContents}</td><td>${ageCellContents}</td></tr>`
+            `<tr class="issue-row">\n<td class="issue-title">${titleCellContents}</td>\n<td class="issue-age">${ageCellContents}</td>\n</tr>`
         );
         expect(results).toContain('</table>');
     });

--- a/src/mariner/index.ts
+++ b/src/mariner/index.ts
@@ -3,3 +3,4 @@ export { readConfigFile, Config } from '../config';
 export { Issue, IssueFinder } from '../issueFinder';
 export { Logger, getLogger, setLogger } from '../tab-level-logger';
 export { generateConfluenceMarkdown } from '../Utilities/generateConfluenceMarkdown';
+export { generateHtml } from '../Utilities/generateHtml';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,10 @@
         /* Basic Options */
         "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
         "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-        "lib": ["es2019", "ES6"] /* Specify library files to be included in the compilation. */,
+        "lib": [
+            "es2019",
+            "ES6"
+        ] /* Specify library files to be included in the compilation. */,
         // "allowJs": true,                       /* Allow javascript files to be compiled. */
         // "checkJs": true,                       /* Report errors in .js files. */
         // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
@@ -17,7 +20,6 @@
         // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
         // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
         // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
         /* Strict Type-Checking Options */
         "strict": true /* Enable all strict type-checking options. */,
         // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -26,13 +28,11 @@
         // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
         // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
         // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
         /* Additional Checks */
         // "noUnusedLocals": true,                /* Report errors on unused locals. */
         // "noUnusedParameters": true,            /* Report errors on unused parameters. */
         // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
         // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
         /* Module Resolution Options */
         // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
@@ -43,17 +43,22 @@
         // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
         // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
         /* Source Map Options */
         // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
         // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
         // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
         // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
         /* Experimental Options */
         // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
         // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     },
-    "include": ["src", "examples/runFasterCode.ts", "examples/runOldCode.ts"],
-    "exclude": ["node_modules", "**/__tests__/*"]
+    "include": [
+        "src",
+        "examples/runExample.ts",
+        "examples/runOldCode.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "**/__tests__/*"
+    ]
 }


### PR DESCRIPTION
Fixed #62 

- Adds a `generateHtml()` function, which is exported by mariner
- Adds unit tests for `generateHtml()`
- Changes the `runFasterCode` example to call `generateHtml()` instead of generating Confluence markup
- Installs a new dependency (html-entities)
- Slightly cleaned up the logic in `generateHtml()`