### PR TITLE
fixes #76

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ You'll also need a GitHub token and a config file. (Keep reading for more info o
 1. Store your GitHub token in your system's environment by running `export MARINER_GITHUB_TOKEN={Insert your GitHub token here}`. You will either have to do this once each time you restart your system, or else configure your system to do so automatically.  
 1. Finally, run the application to find open issues in your dependencies, using the command `node index.js`.
 
-### Optional: Generating Markdown
+### Optional: Generating Markup
 
-- You can generate markdown for use in Confluence/jira
-- The generateConfluenceMarkdown() creates the markdown based on two parameters: `maxIssuesAge` and `issuesByDependency`
+- You can generate markup for use in Confluence/jira
+- The generateConfluenceMarkup() creates the markup based on two parameters: `maxIssuesAge` and `issuesByDependency`
 - `maxIssueAge` defaults to 30 days, anything over 30 days won't get written, You can edit this number.
 - Square brackets and curly braces in issue titles will be replaced by parentheses.
 - You can see an example of how to use in the `runExample.ts` file.
-Example of confluenceMarkdown.md output:
+Example of confluenceMarkup.md output:
 
 ```md
 ## Updated: February 22, 2021, 5:38 PM PST

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ You'll also need a GitHub token and a config file. (Keep reading for more info o
 - The generateConfluenceMarkup() creates the markup based on two parameters: `maxIssuesAge` and `issuesByDependency`
 - `maxIssueAge` defaults to 30 days, anything over 30 days won't get written, You can edit this number.
 - Square brackets and curly braces in issue titles will be replaced by parentheses.
-- You can see an example of how to use in the `runExample.ts` file.
-Example of confluenceMarkup.md output:
+- Example of confluenceMarkup output:
 
 ```md
 ## Updated: February 22, 2021, 5:38 PM PST
@@ -76,9 +75,6 @@ h3. facebook/jest
 ||*Title*||*Age*||
 |[Lost of context between tests when using dynamic ESM import|https://github.com/facebook/jest/issues/10944]|72&nbsp;days|
 ```
-
-- The `runExample.ts` example now demonstrates how to call this new function
-  - <https://github.com/indeedeng/Mariner/blob/master/examples/runExample.ts>
 
 ### Config.json Format
 

--- a/src/Utilities/generateConfluenceMarkup.ts
+++ b/src/Utilities/generateConfluenceMarkup.ts
@@ -1,15 +1,15 @@
 import { DateTime } from 'luxon';
 import { Issue } from '../mariner';
 
-export function generateConfluenceMarkdown(
+export function generateConfluenceMarkup(
     issuesByDependency: Map<string, Issue[]>,
     maxIssuesAge = 30
 ): string {
     const now = DateTime.utc();
 
-    const markdownArray: string[] = [];
+    const markupArray: string[] = [];
 
-    markdownArray.push(`## Updated: ${now.toISO()}`);
+    markupArray.push(`## Updated: ${now.toISO()}`);
 
     for (const [dependency, issues] of issuesByDependency) {
         if (!issues || !issues.length) {
@@ -26,21 +26,19 @@ export function generateConfluenceMarkdown(
             continue;
         }
 
-        markdownArray.push('\n');
-        markdownArray.push(`h3. ${dependency}`);
-        markdownArray.push('||*Title*||*Age*||');
+        markupArray.push('\n');
+        markupArray.push(`h3. ${dependency}`);
+        markupArray.push('||*Title*||*Age*||');
 
         relevantIssues.forEach((issue) => {
             const ageInWholeDays = calculateAgeInWholeDays(issue.createdAt, now);
 
-            const cleanedTitleMarkdown = cleanMarkdown(issue.title);
-            markdownArray.push(
-                `|[${cleanedTitleMarkdown}|${issue.url}]|${ageInWholeDays}&nbsp;days|`
-            );
+            const cleanedTitleMarkup = cleanMarkup(issue.title);
+            markupArray.push(`|[${cleanedTitleMarkup}|${issue.url}]|${ageInWholeDays}&nbsp;days|`);
         });
     }
 
-    return markdownArray.join('\n');
+    return markupArray.join('\n');
 }
 
 export function calculateAgeInWholeDays(isoDateString: string, now: DateTime): number {
@@ -51,7 +49,7 @@ export function calculateAgeInWholeDays(isoDateString: string, now: DateTime): n
     return ageInWholeDays;
 }
 
-export function cleanMarkdown(issueTitle: string): string {
+export function cleanMarkup(issueTitle: string): string {
     const withoutBracesOrBrackets = issueTitle
         .replace(/{/g, '(')
         .replace(/}/g, ')')

--- a/src/Utilities/generateHtml.ts
+++ b/src/Utilities/generateHtml.ts
@@ -1,7 +1,7 @@
 import { encode } from 'html-entities';
 import { DateTime } from 'luxon';
 import { Issue } from '../issueFinder';
-import { calculateAgeInWholeDays } from './generateConfluenceMarkdown';
+import { calculateAgeInWholeDays } from './generateConfluenceMarkup';
 
 export function generateHtml(issuesByDependency: Map<string, Issue[]>, maxIssuesAge = 30): string {
     const now = DateTime.utc();

--- a/src/__tests__/generateConfluenceMarkup.test.ts
+++ b/src/__tests__/generateConfluenceMarkup.test.ts
@@ -1,5 +1,5 @@
 import * as mariner from '../mariner/index';
-import { cleanMarkdown, calculateAgeInWholeDays } from '../Utilities/generateConfluenceMarkdown';
+import { cleanMarkup, calculateAgeInWholeDays } from '../Utilities/generateConfluenceMarkup';
 import { Issue } from '../issueFinder';
 import { DateTime, Duration } from 'luxon';
 
@@ -121,27 +121,27 @@ describe('cleanMarkdown function', () => {
     it('should return string without altering it', () => {
         const title1 =
             '|[Docs: Improve mocks section for promise-based fs/promises | update docs & jest|';
-        const cleanedMarkdown = cleanMarkdown(title1);
+        const cleanedMarkdown = cleanMarkup(title1);
         expect(cleanedMarkdown).toEqual(
             '|(Docs: Improve mocks section for promise-based fs/promises | update docs & jest|'
         );
     });
     it('should remove a set of curly braces', () => {
         const title = '|{WIP} updating frontend components|';
-        const cleanedMarkdown = cleanMarkdown(title);
+        const cleanedMarkdown = cleanMarkup(title);
         expect(cleanedMarkdown).toEqual('|(WIP) updating frontend components|');
     });
     it('should remove all curly braces', () => {
         const title =
             '|{new babel} teardown do not fail tests in non-watch mode - {imports are removed}|';
-        const cleanedMarkdown = cleanMarkdown(title);
+        const cleanedMarkdown = cleanMarkup(title);
         expect(cleanedMarkdown).toEqual(
             '|(new babel) teardown do not fail tests in non-watch mode - (imports are removed)|'
         );
     });
     it('should remove square brackets', () => {
         const title = '|[[es-lint] resolves deprecated code {updates}|';
-        const cleanedMarkdown = cleanMarkdown(title);
+        const cleanedMarkdown = cleanMarkup(title);
         expect(cleanedMarkdown).toEqual('|((es-lint) resolves deprecated code (updates)|');
     });
 });

--- a/src/mariner/index.ts
+++ b/src/mariner/index.ts
@@ -2,5 +2,5 @@ export { DependencyDetailsRetriever } from '../dependency-details-retriever';
 export { readConfigFile, Config } from '../config';
 export { Issue, IssueFinder } from '../issueFinder';
 export { Logger, getLogger, setLogger } from '../tab-level-logger';
-export { generateConfluenceMarkdown } from '../Utilities/generateConfluenceMarkdown';
+export { generateConfluenceMarkup as generateConfluenceMarkdown } from '../Utilities/generateConfluenceMarkup';
 export { generateHtml } from '../Utilities/generateHtml';


### PR DESCRIPTION
changed misname 'markdown' to 'markup', exporting as 'markdown' for now