### PR TITLE
Fix lint and check scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "license": "Apache-2.0",
     "scripts": {
         "test": "jest",
-        "check": "npx eslint --print-config src/* | npx eslint-config-prettier-check",
-        "lint": "npx eslint src/ --ext .js,.ts && echo 'Lint complete'",
-        "lint:fix": "npx eslint src/ --fix --ext .js,.ts && echo 'Fixed errors'",
+        "check": "tsc -noEmit true --project tsconfig.json",
+        "lint": "eslint src/ --ext .js,.ts",
+        "lint:fix": "eslint src/ --fix --ext .js,.ts",
         "build": "tsc",
         "prepublish": "tsc",
         "NOTYET-prepublishOnly": "npm test && npm run lint",


### PR DESCRIPTION
Check script fails
```
$ npm run check

> oss-mariner@0.7.0-beta check /Users/kwitt/Documents/Projects/indeedeng/Mariner
> npx eslint --print-config src/* | npx eslint-config-prettier-check

The --print-config option must be used with exactly one file name.
npx: installed 1 in 1.257s
This is not the tool you are looking for.

See:

https://github.com/prettier/eslint-config-prettier#legacy
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! oss-mariner@0.7.0-beta check: `npx eslint --print-config src/* | npx eslint-config-prettier-check`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the oss-mariner@0.7.0-beta check script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/kwitt/.npm/_logs/2022-03-14T20_14_30_284Z-debug.log

npm failed, show the debug log of the indeed npm wrapper:
command executed: npm run check
command npm  run check
```

The lint script also uses `npx` which will use a version of eslint that may not match the one declared as a dependency. We should use the installed version.